### PR TITLE
Check error before defer commands that may fail.

### DIFF
--- a/cmd/sandboxfs/sandboxfs.go
+++ b/cmd/sandboxfs/sandboxfs.go
@@ -16,8 +16,10 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -26,9 +28,6 @@ import (
 	"time"
 
 	"bazil.org/fuse"
-	"flag"
-	"log"
-
 	"github.com/bazelbuild/sandboxfs/internal/sandbox"
 )
 
@@ -134,18 +133,18 @@ func dynamicCommand(dynamic *flag.FlagSet) error {
 	}
 	if v := dynamic.Lookup("input").Value; v.String() != "-" {
 		file, err := os.Open(v.String())
-		defer file.Close()
 		if err != nil {
 			return fmt.Errorf("Unable to open file %q for reading: %v", v.String(), err)
 		}
+		defer file.Close()
 		dynamicConf.Input = file
 	}
 	if v := dynamic.Lookup("output").Value; v.String() != "-" {
 		file, err := os.Create(v.String())
-		defer file.Close()
 		if err != nil {
 			return fmt.Errorf("Unable to open file %q for writing: %v", v.String(), err)
 		}
+		defer file.Close()
 		dynamicConf.Output = file
 	}
 	return serve(dynamic.Arg(0), dynamicConf, nil)
@@ -166,10 +165,10 @@ func serve(mountPoint string, dynamicConf *sandbox.DynamicConf, mappings []sandb
 		fuse.LocalVolume(),
 		fuse.VolumeName(flag.Lookup("volume_name").Value.String()),
 	)
-	defer c.Close()
 	if err != nil {
 		return fmt.Errorf("Unable to mount: %v", err)
 	}
+	defer c.Close()
 
 	err = sandbox.Serve(c, sfs, dynamicConf)
 	if err != nil {

--- a/integration/layout_test.go
+++ b/integration/layout_test.go
@@ -28,20 +28,18 @@ func TestLayout_MountPointDoesNotExist(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	// TODO(jmmv): sandboxfs currently crashes on a missing mount point, and this is bad.
-	// Must exit cleanly with a proper error message.
-	bogusExitCode := 2
-	bogusWantStderr := "panic"
+	mountPoint := filepath.Join(tempDir, "non-existent")
+	wantStderr := "Unable to mount: mountpoint does not exist: " + mountPoint + "\n"
 
-	stdout, stderr, err := runAndWait(bogusExitCode, "static", "--read_only_mapping=/:"+tempDir, filepath.Join(tempDir, "non-existent"))
+	stdout, stderr, err := runAndWait(1, "static", "--read_only_mapping=/:"+tempDir, mountPoint)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(stdout) > 0 {
 		t.Errorf("got %s; want stdout to be empty", stdout)
 	}
-	if !matchesRegexp(bogusWantStderr, stderr) {
-		t.Errorf("got %s; want stderr to match %s", stderr, bogusWantStderr)
+	if !matchesRegexp(wantStderr, stderr) {
+		t.Errorf("got %s; want stderr to match %s", stderr, wantStderr)
 	}
 }
 


### PR DESCRIPTION
If a file is opened, it returns the file pointer and error. However,
in case of an error, the file pointer would be nil. Thus, the error
needs to be checked, or else `defer file.Close()` may be executed on
a nil pointer causing the program to crash.
Same goes for other function calls like fuse.Mount().

This fixes the bug where sandboxfs would crash on a non-existent mountpoint.