### PR TITLE
Migrate code to use /x/sys/unix instead of syscall wherever possible.

### DIFF
--- a/integration/common.go
+++ b/integration/common.go
@@ -27,11 +27,11 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
 	"bazil.org/fuse"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -84,7 +84,7 @@ func wait(state *runState, wantExitStatus int) (string, string, error) {
 			return state.out.String(), state.err.String(), fmt.Errorf("got %v; want sandboxfs to exit with status 0", err)
 		}
 	} else {
-		status := err.(*exec.ExitError).ProcessState.Sys().(syscall.WaitStatus)
+		status := err.(*exec.ExitError).ProcessState.Sys().(unix.WaitStatus)
 		if wantExitStatus != status.ExitStatus() {
 			return state.out.String(), state.err.String(), fmt.Errorf("got %v; want sandboxfs to exit with status %d", status.ExitStatus(), wantExitStatus)
 		}

--- a/integration/reconfiguration_test.go
+++ b/integration/reconfiguration_test.go
@@ -22,10 +22,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/bazelbuild/sandboxfs/internal/sandbox"
+	"golang.org/x/sys/unix"
 )
 
 // jsonConfig converts a collection of sandbox mappings to the JSON structure expected by sandboxfs.
@@ -136,12 +136,12 @@ func TestReconfiguration_ExplicitStreams(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	inFifo := filepath.Join(tempDir, "input")
-	if err := syscall.Mkfifo(inFifo, 0600); err != nil {
+	if err := unix.Mkfifo(inFifo, 0600); err != nil {
 		t.Fatalf("failed to create %s fifo: %v", inFifo, err)
 	}
 
 	outFifo := filepath.Join(tempDir, "output")
-	if err := syscall.Mkfifo(outFifo, 0600); err != nil {
+	if err := unix.Mkfifo(outFifo, 0600); err != nil {
 		t.Fatalf("failed to create %s fifo: %v", outFifo, err)
 	}
 

--- a/integration/signal_test.go
+++ b/integration/signal_test.go
@@ -17,14 +17,14 @@ package integration
 import (
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 
 	"bazil.org/fuse"
+	"golang.org/x/sys/unix"
 )
 
 func TestSignal_UnmountWhenCaught(t *testing.T) {
-	for _, signal := range []os.Signal{syscall.SIGHUP, os.Interrupt, syscall.SIGTERM} {
+	for _, signal := range []os.Signal{unix.SIGHUP, os.Interrupt, unix.SIGTERM} {
 		t.Run(signal.String(), func(t *testing.T) {
 			state := mountSetup(t, "static", "-read_only_mapping=/:%ROOT%")
 			defer state.tearDown(t)

--- a/internal/sandbox/dir_test.go
+++ b/internal/sandbox/dir_test.go
@@ -20,11 +20,11 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
-	"syscall"
 	"testing"
 
 	"bazil.org/fuse"
 	"golang.org/x/net/context"
+	"golang.org/x/sys/unix"
 )
 
 var OpenRequestDir = &fuse.OpenRequest{
@@ -261,8 +261,8 @@ func TestDir_Mkdir_ReadOnly_Error(t *testing.T) {
 	d := newDir(src, DevInoPair{}, false)
 	mkdirReq := fuse.MkdirRequest{Name: "newDir"}
 
-	if _, err := d.Mkdir(context.Background(), &mkdirReq); err != fuseErrno(syscall.EPERM) {
-		t.Errorf("Mkdir on a read-only directory gave error %T(%v), want fuseErrno(syscall.EPERM)", err, err)
+	if _, err := d.Mkdir(context.Background(), &mkdirReq); err != fuseErrno(unix.EPERM) {
+		t.Errorf("Mkdir on a read-only directory gave error %T(%v), want fuseErrno(unix.EPERM)", err, err)
 	}
 	if _, err := os.Stat(filepath.Join(d.underlyingPath, mkdirReq.Name)); !os.IsNotExist(err) {
 		t.Errorf("Stat got error: %v, want file not found", err)
@@ -283,7 +283,7 @@ func TestDir_Mkdir_ReadWrite_Error(t *testing.T) {
 		Mode: os.ModeDir | 0755,
 	}
 	_, err := d.Mkdir(context.Background(), &req)
-	if e, ok := err.(fuse.Errno); !ok || !os.IsExist(syscall.Errno(e)) {
+	if e, ok := err.(fuse.Errno); !ok || !os.IsExist(unix.Errno(e)) {
 		t.Errorf("Mkdir returned error: %v, want fuse.Errno(os.IsExist(err))", err)
 	}
 }
@@ -324,8 +324,8 @@ func TestDir_Mknod_ReadOnly_Error(t *testing.T) {
 	d := newDir(src, DevInoPair{}, false)
 	mknodReq := fuse.MknodRequest{Name: "newNode"}
 
-	if _, err := d.Mknod(context.Background(), &mknodReq); err != fuseErrno(syscall.EPERM) {
-		t.Errorf("Mknod on a read-only directory gave error %T(%v), want fuseErrno(syscall.EPERM)", err, err)
+	if _, err := d.Mknod(context.Background(), &mknodReq); err != fuseErrno(unix.EPERM) {
+		t.Errorf("Mknod on a read-only directory gave error %T(%v), want fuseErrno(unix.EPERM)", err, err)
 	}
 	if _, err := os.Stat(filepath.Join(d.underlyingPath, mknodReq.Name)); !os.IsNotExist(err) {
 		t.Errorf("Stat got error: %v, want file not found", err)
@@ -343,11 +343,11 @@ func TestDir_Mknod_ReadWrite_Error(t *testing.T) {
 
 	req := fuse.MknodRequest{
 		Name: "newNode",
-		Mode: syscall.S_IFIFO | 0644,
+		Mode: unix.S_IFIFO | 0644,
 	}
 
 	_, err := d.Mknod(context.Background(), &req)
-	if e, ok := err.(fuse.Errno); !ok || !os.IsExist(syscall.Errno(e)) {
+	if e, ok := err.(fuse.Errno); !ok || !os.IsExist(unix.Errno(e)) {
 		t.Errorf("Mknod returned error: %v, want fuse.Errno(os.IsExist(err))", err)
 	}
 }
@@ -360,7 +360,7 @@ func TestDir_Mknod_ReadWrite_Ok(t *testing.T) {
 	const perm = 0644
 	req := fuse.MknodRequest{
 		Name: "newNode",
-		Mode: syscall.S_IFIFO | perm,
+		Mode: unix.S_IFIFO | perm,
 	}
 
 	n, err := d.Mknod(context.Background(), &req)
@@ -388,8 +388,8 @@ func TestDir_Create_ReadOnly_Error(t *testing.T) {
 	createReq := fuse.CreateRequest{Name: "newFile"}
 	createResp := fuse.CreateResponse{}
 
-	if _, _, err := d.Create(context.Background(), &createReq, &createResp); err != fuseErrno(syscall.EPERM) {
-		t.Errorf("Create on a read-only directory gave error %T(%v), want fuseErrno(syscall.EPERM)", err, err)
+	if _, _, err := d.Create(context.Background(), &createReq, &createResp); err != fuseErrno(unix.EPERM) {
+		t.Errorf("Create on a read-only directory gave error %T(%v), want fuseErrno(unix.EPERM)", err, err)
 	}
 	if _, err := os.Stat(filepath.Join(d.underlyingPath, createReq.Name)); !os.IsNotExist(err) {
 		t.Errorf("Stat got error: %v, want file not found", err)
@@ -457,8 +457,8 @@ func TestDir_Symlink_ReadOnly_Error(t *testing.T) {
 	d := newDir(src, DevInoPair{}, false)
 	symlinkReq := fuse.SymlinkRequest{NewName: "newNode", Target: "."}
 
-	if _, err := d.Symlink(context.Background(), &symlinkReq); err != fuseErrno(syscall.EPERM) {
-		t.Errorf("Symlink on a read-only directory gave error %T(%v), want fuseErrno(syscall.EPERM)", err, err)
+	if _, err := d.Symlink(context.Background(), &symlinkReq); err != fuseErrno(unix.EPERM) {
+		t.Errorf("Symlink on a read-only directory gave error %T(%v), want fuseErrno(unix.EPERM)", err, err)
 	}
 	if _, err := os.Stat(filepath.Join(d.underlyingPath, symlinkReq.NewName)); !os.IsNotExist(err) {
 		t.Errorf("Stat got error: %v, want file not found", err)
@@ -475,8 +475,8 @@ func TestDir_Symlink_ReadWrite_Error(t *testing.T) {
 	d := newDir(src, DevInoPair{}, true)
 	symlinkReq := fuse.SymlinkRequest{NewName: "newNode", Target: "."}
 
-	if _, err := d.Symlink(context.Background(), &symlinkReq); err != fuseErrno(syscall.EACCES) {
-		t.Errorf("Symlink gave error %T(%v), want fuseErrno(syscall.EACCES)", err, err)
+	if _, err := d.Symlink(context.Background(), &symlinkReq); err != fuseErrno(unix.EACCES) {
+		t.Errorf("Symlink gave error %T(%v), want fuseErrno(unix.EACCES)", err, err)
 	}
 }
 
@@ -514,7 +514,7 @@ func TestDir_Rename_ReadOnly_Error(t *testing.T) {
 	renameReq := fuse.RenameRequest{OldName: "a", NewName: "b"}
 
 	err := d.Rename(context.Background(), &renameReq, d)
-	if e, ok := err.(fuse.Errno); !ok || !os.IsNotExist(syscall.Errno(e)) {
+	if e, ok := err.(fuse.Errno); !ok || !os.IsNotExist(unix.Errno(e)) {
 		t.Errorf("Rename from a read-only directory gave error %T(%v), want fuseErrno(os.IsNotExist(err))", err, err)
 	}
 }
@@ -529,8 +529,8 @@ func TestDir_Rename_ReadWrite_Error(t *testing.T) {
 	}
 	renameReq := fuse.RenameRequest{OldName: "a", NewName: "b"}
 
-	if err := d.Rename(context.Background(), &renameReq, d); err != fuseErrno(syscall.EPERM) {
-		t.Errorf("Rename from a read-only directory gave error %T(%v), want fuseErrno(syscall.EPERM)", err, err)
+	if err := d.Rename(context.Background(), &renameReq, d); err != fuseErrno(unix.EPERM) {
+		t.Errorf("Rename from a read-only directory gave error %T(%v), want fuseErrno(unix.EPERM)", err, err)
 	}
 }
 
@@ -591,8 +591,8 @@ func TestDir_Remove_ReadOnly_Error(t *testing.T) {
 	}
 	removeReq := fuse.RemoveRequest{Name: "c"}
 
-	if err := d.Remove(context.Background(), &removeReq); err != fuseErrno(syscall.EPERM) {
-		t.Errorf("Remove from a read-only directory gave error %T(%v), want fuseErrno(syscall.EPERM)", err, err)
+	if err := d.Remove(context.Background(), &removeReq); err != fuseErrno(unix.EPERM) {
+		t.Errorf("Remove from a read-only directory gave error %T(%v), want fuseErrno(unix.EPERM)", err, err)
 	}
 	if _, err := os.Stat(filepath.Join(d.underlyingPath, removeReq.Name)); err != nil {
 		t.Errorf("Stat got error: %v, want nil", err)
@@ -612,8 +612,8 @@ func TestDir_Remove_ReadWrite_Ok(t *testing.T) {
 	if err := d.Remove(context.Background(), &req); err != nil {
 		t.Errorf("Remove call gave error %T(%v), want nil", err, err)
 	}
-	if _, err := os.Stat(filepath.Join(d.UnderlyingPath(), req.Name)); fuseErrno(err) != fuse.Errno(syscall.ENOENT) {
-		t.Errorf("Stat on removed file gave err: %v, want: %v", err, syscall.ENOENT)
+	if _, err := os.Stat(filepath.Join(d.UnderlyingPath(), req.Name)); fuseErrno(err) != fuse.Errno(unix.ENOENT) {
+		t.Errorf("Stat on removed file gave err: %v, want: %v", err, unix.ENOENT)
 	}
 }
 

--- a/internal/sandbox/file.go
+++ b/internal/sandbox/file.go
@@ -17,11 +17,11 @@ package sandbox
 import (
 	"io"
 	"os"
-	"syscall"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"golang.org/x/net/context"
+	"golang.org/x/sys/unix"
 )
 
 // File corresponds to files in an in-memory representation of the filesystem
@@ -83,7 +83,7 @@ func (o *OpenFile) Read(_ context.Context, req *fuse.ReadRequest, resp *fuse.Rea
 // filesystem.
 func (o *OpenFile) Write(_ context.Context, req *fuse.WriteRequest, resp *fuse.WriteResponse) error {
 	if !o.file.writable {
-		return fuseErrno(syscall.EPERM)
+		return fuseErrno(unix.EPERM)
 	}
 
 	n, err := o.nativeFile.WriteAt(req.Data, req.Offset)

--- a/internal/sandbox/file_test.go
+++ b/internal/sandbox/file_test.go
@@ -17,12 +17,12 @@ package sandbox
 import (
 	"io/ioutil"
 	"os"
-	"syscall"
 	"testing"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"golang.org/x/net/context"
+	"golang.org/x/sys/unix"
 )
 
 var OpenRequestFile = &fuse.OpenRequest{
@@ -115,8 +115,8 @@ func TestFile_Write_Error(t *testing.T) {
 	}
 	writeResp := &fuse.WriteResponse{}
 
-	if err := h.(*OpenFile).Write(context.Background(), writeReq, writeResp); err != fuseErrno(syscall.EPERM) {
-		t.Errorf("Read-only file write failed with error: %T(%v), want: fuse.Errno(syscall.EPERM)", err, err)
+	if err := h.(*OpenFile).Write(context.Background(), writeReq, writeResp); err != fuseErrno(unix.EPERM) {
+		t.Errorf("Read-only file write failed with error: %T(%v), want: fuse.Errno(unix.EPERM)", err, err)
 	}
 	if text, err := ioutil.ReadFile(src + "/a"); err != nil || string(text) != content {
 		t.Errorf("ReadFile got (%q, %v), expected (%q, nil)", string(text), err, content)

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -32,7 +33,6 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"golang.org/x/sys/unix"
-	"log"
 )
 
 // lastInodeNumber is a counter that contains the last allotted inode number.
@@ -198,7 +198,7 @@ func (f *FS) SetRoot(root *Root) {
 	f.root = root
 }
 
-// timespecToTime converts syscall.Timespec to time.Time.
+// timespecToTime converts unix.Timespec to time.Time.
 func timespecToTime(ts syscall.Timespec) time.Time {
 	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
 }
@@ -236,15 +236,15 @@ func fuseErrno(e error) error {
 	}
 	switch e {
 	case os.ErrInvalid:
-		return fuse.Errno(syscall.EINVAL)
+		return fuse.Errno(unix.EINVAL)
 	case os.ErrPermission:
-		return fuse.Errno(syscall.EPERM)
+		return fuse.Errno(unix.EPERM)
 	case os.ErrExist:
-		return fuse.Errno(syscall.EEXIST)
+		return fuse.Errno(unix.EEXIST)
 	case os.ErrNotExist:
-		return fuse.Errno(syscall.ENOENT)
+		return fuse.Errno(unix.ENOENT)
 	case os.ErrClosed:
-		return fuse.Errno(syscall.EBADF)
+		return fuse.Errno(unix.EBADF)
 	}
 	return e
 }

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -20,10 +20,10 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"syscall"
 	"testing"
 
 	"bazil.org/fuse"
+	"golang.org/x/sys/unix"
 )
 
 func setup(t *testing.T) string {
@@ -71,7 +71,7 @@ func TestSandbox_TimespecToTime(t *testing.T) {
 		{1000, 1000},
 	}
 	for _, data := range testData {
-		ts := syscall.Timespec{Sec: data.sec, Nsec: data.nanosec}
+		ts := unix.Timespec{Sec: data.sec, Nsec: data.nanosec}
 		if time := timespecToTime(ts); time.Unix() != data.sec || time.Nanosecond() != int(data.nanosec) {
 			t.Errorf("timespecToTime failed: got (%v, %v), want (%v, %v)", time.Unix(), time.Nanosecond(), data.sec, data.nanosec)
 		}
@@ -84,8 +84,8 @@ func TestSandbox_FuseErrno(t *testing.T) {
 		t.Error("Chmod passed, even though error was expected")
 	}
 	err = fuseErrno(err)
-	if e, ok := err.(fuse.Errno); !ok || e != fuse.Errno(syscall.ENOENT) {
-		t.Errorf("Returned error was %T(%v), want fuse.Errno(syscall.ENOENT)", err, err)
+	if e, ok := err.(fuse.Errno); !ok || e != fuse.Errno(unix.ENOENT) {
+		t.Errorf("Returned error was %T(%v), want fuse.Errno(unix.ENOENT)", err, err)
 	}
 
 	_, err = os.Readlink("/")
@@ -96,7 +96,7 @@ func TestSandbox_FuseErrno(t *testing.T) {
 		t.Errorf("Returned error was of type %T, want fuse.Errno", fuseErrno(err))
 	}
 
-	err = syscall.Chdir("")
+	err = unix.Chdir("")
 	if err == nil {
 		t.Error("Chdir passed, even though error was expected")
 	}

--- a/internal/sandbox/symlink_test.go
+++ b/internal/sandbox/symlink_test.go
@@ -17,10 +17,10 @@ package sandbox
 import (
 	"io/ioutil"
 	"os"
-	"syscall"
 	"testing"
 
 	"golang.org/x/net/context"
+	"golang.org/x/sys/unix"
 )
 
 func symlinkSetup(t *testing.T) string {
@@ -66,7 +66,7 @@ func TestSymlink_Readlink_Error(t *testing.T) {
 
 	d := newSymlink(src+"/A/B", DevInoPair{})
 	_, err := d.Readlink(context.Background(), nil)
-	if err != fuseErrno(syscall.EINVAL) {
-		t.Errorf("Readlink returned error %v, expected %v:", err, fuseErrno(syscall.EINVAL))
+	if err != fuseErrno(unix.EINVAL) {
+		t.Errorf("Readlink returned error %v, expected %v:", err, fuseErrno(unix.EINVAL))
 	}
 }

--- a/internal/sandbox/virtual_dir.go
+++ b/internal/sandbox/virtual_dir.go
@@ -17,11 +17,11 @@ package sandbox
 import (
 	"fmt"
 	"os"
-	"syscall"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"golang.org/x/net/context"
+	"golang.org/x/sys/unix"
 )
 
 // VirtualDir is a node type that represents a virtual directory in the file
@@ -76,7 +76,7 @@ func (v *VirtualDir) Open(context.Context, *fuse.OpenRequest, *fuse.OpenResponse
 // Access checks for permissions on a given node in the file system.
 func (v *VirtualDir) Access(_ context.Context, req *fuse.AccessRequest) error {
 	if req.Mask&2 != 0 { // W_OK permission == 2
-		return fuseErrno(syscall.EACCES)
+		return fuseErrno(unix.EACCES)
 	}
 	return nil
 }
@@ -173,7 +173,7 @@ func (v *VirtualDir) lookup(name string) (fs.Node, error) {
 	if child, ok := v.virtualDirs[name]; ok {
 		return child, nil
 	}
-	return nil, fuseErrno(syscall.ENOENT)
+	return nil, fuseErrno(unix.ENOENT)
 }
 
 // invalidateRecursively clears the kernel cache corresponding to this node,

--- a/internal/sandbox/virtual_dir_test.go
+++ b/internal/sandbox/virtual_dir_test.go
@@ -17,11 +17,11 @@ package sandbox
 import (
 	"os"
 	"sort"
-	"syscall"
 	"testing"
 
 	"bazil.org/fuse"
 	"golang.org/x/net/context"
+	"golang.org/x/sys/unix"
 )
 
 func TestVirtualDir_Attr(t *testing.T) {
@@ -39,8 +39,8 @@ func TestVirtualDir_Attr(t *testing.T) {
 func TestVirtualDir_Lookup(t *testing.T) {
 	dir := newVirtualDir()
 	node, err := dir.Lookup(context.Background(), "A")
-	if err != fuseErrno(syscall.ENOENT) {
-		t.Errorf("Lookup on empty node returned error: nil, want: syscall.ENOENT")
+	if err != fuseErrno(unix.ENOENT) {
+		t.Errorf("Lookup on empty node returned error: nil, want: unix.ENOENT")
 	}
 	if node != nil {
 		t.Errorf("Lookup on empty node returned node: %v, want: nil", node)


### PR DESCRIPTION
According to https://golang.org/pkg/syscall/, the syscall package is now locked down and existing code should be ported to use /x/sys/unix whenever possible.
References to Stat_t still use the old syscall package due to values returned by existing library packages.