### PR TITLE
Add Bazel build scripts, source code linting, and IDE integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.*.orig
+.*.rej
+.*.swp
+.*~
+/bazel-*

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .*.swp
 .*~
 /bazel-*
+/.gopath
+/.gopath-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ go_import_path: github.com/bazelbuild/sandboxfs
 env:
   - DO=bazel
   - DO=gotools
+  - DO=lint
 
 before_install: ./admin/travis-install.sh
 script: ./admin/travis-build.sh
@@ -42,4 +43,11 @@ matrix:
     - env: DO=gotools
       go: 1.8
     - go: 1.8
+      os: osx
+
+    # For code linting, we just need to run this under a single configuration.
+    # Trim all but one, and prefer Linux over macOS because it's much faster.
+    - env: DO=lint
+      go: 1.8
+    - env: DO=lint
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,28 @@ os:
   - linux
   - osx
 
-language: go
+language:
+  - go  # For ourselves.
+  - java  # For Bazel.
+
 go:
   - 1.8
   - 1.9
 go_import_path: github.com/bazelbuild/sandboxfs
 
+env:
+  - DO=bazel
+  - DO=gotools
+
 before_install: ./admin/travis-install.sh
 script: ./admin/travis-build.sh
+
+matrix:
+  exclude:
+    # For Go 1.8, we are only interested in testing that our code builds
+    # correctly under that version of the language.  A single test is sufficient
+    # for this, so remove all other configurations.
+    - env: DO=gotools
+      go: 1.8
+    - go: 1.8
+      os: osx

--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,1 @@
+settings.json

--- a/.vscode/settings.json.in
+++ b/.vscode/settings.json.in
@@ -1,0 +1,38 @@
+{
+  "editor.insertSpaces": true,
+  "editor.rulers": [80],
+  "editor.tabSize": 2,
+  "editor.wordWrapColumn": 80,
+
+  "files.associations": {
+    "settings.json.in": "json"
+  },
+  "files.exclude": {
+    "**/.DS_Store": true,
+    "**/.git": true,
+    ".gopath-tools/**": true,
+    ".gopath/**": true,
+    "bazel-*": true,
+    "settings.json": true
+  },
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+
+  "go.formatOnSave": true,
+  "go.gopath": "__GOPATH__",
+  "go.goroot": "__GOROOT__",
+  "go.toolsGopath": "__TOOLS_GOPATH__",
+  "go.useLanguageServer": true,
+
+  "[go]": {
+    "editor.insertSpaces": false,
+    "editor.rulers": [100],
+    "editor.tabSize": 8,
+    "editor.wordWrapColumn": 100
+  },
+
+  "[makefile]": {
+    "editor.insertSpaces": false,
+    "editor.tabSize": 8
+  }
+}

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,3 @@
+licenses(["notice"])  # Apache License 2.0
+
+exports_files(["WORKSPACE"])

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,17 @@
 licenses(["notice"])  # Apache License 2.0
 
 exports_files(["WORKSPACE"])
+
+filegroup(
+    name = "distdocs",
+    srcs = [
+        "AUTHORS",
+        "CONTRIBUTING.md",
+        "CONTRIBUTORS",
+        "INSTALL.md",
+        "LICENSE",
+        "NEWS.md",
+        "README.md",
+    ],
+    visibility = ["//admin/install:__pkg__"],
+)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ this integrates with a variety of tools that you will need during development.
 Read the [installation instructions](INSTALL.md) for details on how to get
 started.
 
+Once you have Bazel installed, you *must* run the `./configure` script to
+prepare your source tree for development.  In its simplest form, this will
+install necessary Git hooks into the current workspace.  Failure to do so will
+potentially result in commits that are not up to the standards that we expect
+and delay your code reviews.
+
 ## Updating BUILD.bazel files
 
 We use the Gazelle tool to maintain the Go targets in the `BUILD.bazel` files
@@ -40,6 +46,15 @@ throughout the project.
 If you find yourself needing to modify any of the `go_*` rules, stop and
 run `bazel run //admin:gazelle` instead.  This will take care of updating the
 build rules automatically.
+
+## Code formatting and linting
+
+At commit time, our pre-commit script will verify that any changes you have
+made comply with the expected coding style.  If there are any problems, you
+will see a report on the command-line with the specifics.
+
+If you want to run the style check by hand, you can invoke it with the
+`bazel run //admin/lint` command.
 
 ## Code reviews
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 # Contributing
 
-Want to contribute?  Great!  First, read this page (including the small print
-at the end).
+Want to contribute?  Great!  First, read this page in its entirety.
 
 ## Before you contribute
 
@@ -17,24 +16,38 @@ infringes on other people's patents.  You don't have to sign the CLA until
 after you've submitted your code for review and a member has approved it, but
 you must do it before we can put your code into our codebase.
 
+Contributions made by corporations are covered by a different agreement than
+the one above, the [Software Grant and Corporate Contributor License
+Agreement](https://cla.developers.google.com/about/google-corporate).
+
 Before you start working on a larger contribution, you should get in touch with
 us first through the issue tracker with your idea so that we can help out and
 possibly guide you.  Coordinating up front makes it much easier to avoid
 frustration later on.
 
+## Project setup
+
+In order to contribute to sandboxfs, you *must* use the Bazel build system, as
+this integrates with a variety of tools that you will need during development.
+Read the [installation instructions](INSTALL.md) for details on how to get
+started.
+
+## Updating BUILD.bazel files
+
+We use the Gazelle tool to maintain the Go targets in the `BUILD.bazel` files
+throughout the project.
+
+If you find yourself needing to modify any of the `go_*` rules, stop and
+run `bazel run //admin:gazelle` instead.  This will take care of updating the
+build rules automatically.
+
 ## Code reviews
 
 All submissions, including submissions by project members, require review.
-We use Github pull requests for this purpose.
+We use GitHub pull requests for this purpose.
 
 Be aware that the copy of sandboxfs in GitHub is not *yet* primary: all
 changes submitted via GitHub bugs or pull requests will be manually applied
 to the Google-internal tree, reviewed there, and then reexported to GitHub
 (which means your commit IDs will change, but attribution should not).  Our
 goal is to make GitHub the primary copy, but we are not there yet!
-
-## The small print
-
-Contributions made by corporations are covered by a different agreement than
-the one above, the [Software Grant and Corporate Contributor License
-Agreement](https://cla.developers.google.com/about/google-corporate).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,16 @@ If you find yourself needing to modify any of the `go_*` rules, stop and
 run `bazel run //admin:gazelle` instead.  This will take care of updating the
 build rules automatically.
 
+## IDE support
+
+sandboxfs' build scripts integrate well with the [Visual Studio Code
+(VSCode)](https://code.visualstudio.com/) editor.
+
+To enable support for VSCode, run `./configure --enable-vscode`.  This will
+generate a `settings.json` file for the project that points to the right
+locations of the Go tools and will also create a fake `GOPATH` that the tools
+can consume.
+
 ## Code formatting and linting
 
 At commit time, our pre-commit script will verify that any changes you have

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,8 +23,23 @@ To get started:
         and remove the `go_version = "host"` parameter from the
         `go_register_toolchains` statement.
 
-1.  Run `bazel build //cmd/sandboxfs` to download all required dependencies
-    and build the final binary.
+1.  Run `bazel build //admin/install` to download all required dependencies,
+    build the final binary, and build the installation tool.
+
+1.  To copy all binary and data files to the default destination of
+    `/usr/local`, run `./bazel-bin/admin/install/install`.
+
+    *   You will (most likely) need superuser permissions to install
+        under `/usr/local`, so run the previous command with `sudo`.
+
+    *   The reason the above command is not `sudo bazel run ...` is because
+        running Bazel under `sudo` will cause a full rebuild of everything.
+        Don't run Bazel as root.  Instead, just build the installation tool
+        first and run it separately, as described above.
+
+    *   If you want to install sandboxfs under a custom prefix, run
+        `./bazel-bin/admin/install/install --prefix=/path/to/prefix`
+        instead.
 
 ## From sources with the Go tools
 
@@ -33,3 +48,7 @@ standard Go tools as follows:
 
     go get github.com/bazelbuild/sandboxfs/cmd/sandboxfs
     go build github.com/bazelbuild/sandboxfs/cmd/sandboxfs
+
+This is not recommended because this mechanism does not provide a way to
+install the built product.  (Yes, `go install` does install the binary but does
+not handle other support files such as documentation.)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,35 @@
+# Installation instructions
+
+Given that there have not yet been any formal releases of sandboxfs, there
+currently are no prebuilt binaries available.  To use sandboxfs, you will
+have to build and install it from a fresh checkout of the GitHub tree.
+
+## From sources with Bazel
+
+The preferred mechanism to build sandboxfs is to use the
+[Bazel](http://bazel.build) build system.  The reason is that this provides
+a reproducible build environment with pinned versions of all required
+dependencies and also integrates well with various support tools used
+during installation and during development.
+
+To get started:
+
+1.  [Download and install Bazel](https://bazel.build/).
+
+1.  [Download and install Go](https://golang.org/).
+
+    *   If you don't want to do this by hand and would rather have Bazel
+        manage the installation of Go for you, edit the `WORKSPACE` file
+        and remove the `go_version = "host"` parameter from the
+        `go_register_toolchains` statement.
+
+1.  Run `bazel build //cmd/sandboxfs` to download all required dependencies
+    and build the final binary.
+
+## From sources with the Go tools
+
+You can also build and install sandboxfs from this Git repository using the
+standard Go tools as follows:
+
+    go get github.com/bazelbuild/sandboxfs/cmd/sandboxfs
+    go build github.com/bazelbuild/sandboxfs/cmd/sandboxfs

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ not an official Google product.
 sandboxfs is still under active development and there have not yet been any
 formal releases.
 
+See the [installation instructions](INSTALL.md) for details on how to build
+and install sandboxfs.
+
 See the [release notes](NEWS.md) file for more details.
 
 ## Usage
@@ -32,6 +35,5 @@ following command after cloning the tree:
 ## Contributing
 
 If you'd like to contribute to sandboxfs, there is plenty of work to be
-done!  As a start, you can look into all the `TODO`s sprinkled throughout
-the codebase.  But before you dive into contributing, please make sure to
-read our [contribution guidelines](CONTRIBUTING.md).
+done!  Please make sure to read our [contribution guidelines](CONTRIBUTING.md)
+to learn about some important prerequisite steps.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,17 @@ load(
 go_register_toolchains(go_version = "host")
 
 go_repository(
+    name = "bazel_gopath",
+    importpath = "github.com/DarkDNA/bazel-gopath",
+    commit = "f83ae8d403d0c826335a5edf4bbd1f7b0cf176e4",
+
+    # bazel-gopath ships with a proto file and also a precompiled version of it.
+    # The proto file does not include the right Go options, which confuses
+    # Gazelle, so prefer the precompiled version.
+    build_file_proto_mode = "disable",
+)
+
+go_repository(
     name = "golint",
     importpath = "github.com/golang/lint",
     commit = "6aaf7c34af0f4c36a57e0c429bace4d706d8e931",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,30 @@
+workspace(name = "sandboxfs")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.7.0/rules_go-0.7.0.tar.gz",
+    sha256 = "91fca9cf860a1476abdc185a5f675b641b60d3acf0596679a27b580af60bf19c",
+)
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_register_toolchains",
+    "go_repository",
+    "go_rules_dependencies",
+)
+
+go_register_toolchains(go_version = "host")
+
+go_repository(
+    name = "org_bazil_fuse",
+    importpath = "bazil.org/fuse",
+    commit = "371fbbdaa8987b715bdd21d6adc4c9b20155f748",
+)
+
+go_repository(
+    name = "org_golang_x_sys",
+    importpath = "golang.org/x/sys",
+    commit = "4b45465282a4624cf39876842a017334f13b8aff",
+)
+
+go_rules_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,12 @@ load(
 go_register_toolchains(go_version = "host")
 
 go_repository(
+    name = "golint",
+    importpath = "github.com/golang/lint",
+    commit = "6aaf7c34af0f4c36a57e0c429bace4d706d8e931",
+)
+
+go_repository(
     name = "org_bazil_fuse",
     importpath = "bazil.org/fuse",
     commit = "371fbbdaa8987b715bdd21d6adc4c9b20155f748",

--- a/admin/BUILD.bazel
+++ b/admin/BUILD.bazel
@@ -1,0 +1,8 @@
+licenses(["notice"])  # Apache License 2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "gazelle")
+
+gazelle(
+    name = "gazelle",
+    prefix = "github.com/bazelbuild/sandboxfs",
+)

--- a/admin/install/BUILD.bazel
+++ b/admin/install/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["install.go"],
+    importpath = "github.com/bazelbuild/sandboxfs/admin/install",
+    visibility = ["//visibility:private"],
+    deps = ["//internal/shell:go_default_library"],
+)
+
+go_binary(
+    name = "install",
+    data = [
+        "//:distdocs",
+        "//cmd/sandboxfs",
+        "//cmd/sandboxfs:manpage",
+    ],
+    importpath = "github.com/bazelbuild/sandboxfs/admin/install",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/admin/install/install.go
+++ b/admin/install/install.go
@@ -1,0 +1,120 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// The install binary installs sandboxfs and all of its support files.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/bazelbuild/sandboxfs/internal/shell"
+)
+
+const (
+	// Relative path to the runfiles directory for the install script.  Used if the script is
+	// run by hand from the workspace directory, without using "bazel run".
+	runfiles = "bazel-bin/admin/install/install.runfiles/sandboxfs"
+
+	// Path to the built sandboxfs binary relative to the runfiles directory.
+	sandboxfsBin = "cmd/sandboxfs/sandboxfs"
+
+	// Desired permissions for installed files.
+	dataPerm = 0644
+	execPerm = 0755
+	dirPerm  = 0755
+)
+
+// installSpec contains the details for the installation of one source file.
+type installSpec struct {
+	// sourceFile contains the relative path to the source file to be installed.  If ran with
+	// Bazel, all source files must be present in the runfiles directory of this tool, which
+	// means they all must be listed as data dependencies.
+	sourceFile string
+
+	// targetDir indicates the relative path from the prefix where the file will be installed.
+	// The name of the installed file matches the name of the source file.
+	targetDir string
+
+	// mode indicates the desired permissions of the installed file.
+	mode os.FileMode
+}
+
+// doInstall performs the installation of all given files into the prefix.
+func doInstall(sourceDir string, prefix string, filesToInstall []installSpec) error {
+	for _, spec := range filesToInstall {
+		sourceFile := filepath.Join(sourceDir, spec.sourceFile)
+
+		targetDir := filepath.Join(prefix, spec.targetDir)
+		if err := os.MkdirAll(targetDir, dirPerm); err != nil {
+			return fmt.Errorf("failed to create %s: %v", targetDir, err)
+		}
+
+		targetFile := filepath.Join(targetDir, filepath.Base(spec.sourceFile))
+		if err := shell.Install(sourceFile, targetFile, spec.mode); err != nil {
+			return fmt.Errorf("failed to copy %s to %s: %v", spec.sourceFile, targetFile, err)
+		}
+	}
+	return nil
+}
+
+// guessSourceDir returns the directory that contains the built files to be installed in the layout
+// expected by the installData contents.
+func guessSourceDir() (string, error) {
+	// First check if the built sandboxfs binary is reachable from the current directory.  If it
+	// is, we are running from within the runfiles directory via "blaze run".
+	_, err := os.Stat(sandboxfsBin)
+	if err != nil {
+		// We aren't running via "blaze run".  Check and see if the built sandboxfs binary
+		// is reachable from the blaze-bin directory and, if it is, use that.
+		_, err := os.Stat(filepath.Join(runfiles, sandboxfsBin))
+		if err != nil {
+			return "", fmt.Errorf("cannot determine location of files to be installed, or was //cmd/sandboxfs not yet built?")
+		}
+		return runfiles, nil
+	}
+	return ".", nil
+}
+
+func main() {
+	prefix := flag.String("prefix", "/usr/local", "Location where to install sandboxfs")
+	flag.Parse()
+
+	filesToInstall := []installSpec{
+		{sandboxfsBin, "bin", execPerm},
+
+		{"AUTHORS", "share/doc/sandboxfs", dataPerm},
+		{"CONTRIBUTING.md", "share/doc/sandboxfs", dataPerm},
+		{"CONTRIBUTORS", "share/doc/sandboxfs", dataPerm},
+		{"INSTALL.md", "share/doc/sandboxfs", dataPerm},
+		{"LICENSE", "share/doc/sandboxfs", dataPerm},
+		{"NEWS.md", "share/doc/sandboxfs", dataPerm},
+		{"README.md", "share/doc/sandboxfs", dataPerm},
+
+		{"cmd/sandboxfs/sandboxfs.1", "share/man/man1", dataPerm},
+	}
+
+	sourceDir, err := guessSourceDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := doInstall(sourceDir, *prefix, filesToInstall); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/admin/lint/BUILD.bazel
+++ b/admin/lint/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "gazelle", "go_binary", "go_library")
+
+# TODO(jmmv): Remove this duplicate rule from //admin when the gazelle rule
+# supports a visibility attribute.
+gazelle(
+    name = "gazelle",
+    prefix = "github.com/bazelbuild/sandboxfs",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "checks.go",
+        "lint.go",
+    ],
+    importpath = "github.com/bazelbuild/sandboxfs/admin/lint",
+    visibility = ["//visibility:private"],
+    deps = ["//internal/shell:go_default_library"],
+)
+
+go_binary(
+    name = "lint",
+    data = [
+        ":gazelle",
+        "//:WORKSPACE",
+        "@com_github_bazelbuild_buildtools//buildifier",
+        "@go_sdk//:bin/gofmt",
+        "@golint//golint",
+    ],
+    importpath = "github.com/bazelbuild/sandboxfs/admin/lint",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/admin/lint/checks.go
+++ b/admin/lint/checks.go
@@ -1,0 +1,156 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+
+	"github.com/bazelbuild/sandboxfs/internal/shell"
+)
+
+const (
+	// Paths to the tools as staged by the data attribute of this binary and as reachable from a
+	// "blaze run" invocation.
+	buildifierBin = "../com_github_bazelbuild_buildtools/buildifier/buildifier"
+	gazelleBin    = "admin/lint/gazelle"
+	gofmtBin      = "../go_sdk/bin/gofmt"
+	golintBin     = "../golint/golint/golint"
+)
+
+// checkLicense checks if the given file contains the necessary license information and returns an
+// error if this is not true or if the check cannot be performed.
+func checkLicense(file string) error {
+	for _, pattern := range []string{
+		`Copyright.*Google`,
+		`Apache License.*2.0`,
+	} {
+		matched, err := shell.Grep(pattern, file)
+		if err != nil {
+			return fmt.Errorf("license check failed for %s: %v", file, err)
+		}
+		if !matched {
+			return fmt.Errorf("license check failed for %s: %s not found", file, pattern)
+		}
+	}
+
+	return nil
+}
+
+// runLinter is a helper function to run a linter that prints diagnostics to stdout and returns true
+// even when the given files are not compliant.  The arguments indicate the full command line to
+// run, including the path to the tool as the first argument.  The file to check is expected to
+// appear as the last argument.
+func runLinter(arg ...string) error {
+	toolName := filepath.Base(arg[0])
+	file := arg[len(arg)-1]
+
+	var output bytes.Buffer
+	cmd := exec.Command(arg[0], arg[1:]...)
+	cmd.Stdout = &output
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("%s check failed for %s: %v", toolName, file, err)
+	}
+	if output.Len() > 0 {
+		fmt.Printf("%s does not pass %s:\n", file, toolName)
+		fmt.Println(output.String())
+		return fmt.Errorf("%s check failed for %s: not compliant", toolName, file)
+	}
+	return nil
+}
+
+// checkBuildifier checks if the given file is formatted according to buildifier and, if not, prints
+// a diff detailing what's wrong with the file to stdout and returns an error.
+func checkBuildifier(file string) error {
+	return runLinter(buildifierBin, "--mode=diff", file)
+}
+
+// checkGazelle checks if the given file is formatted according to gazelle and, if not, prints
+// a diff detailing what's wrong with the file to stdout and returns an error.
+func checkGazelle(file string) error {
+	// TODO(jmmv): Remove /bin/sh argument once the gazelle generated script is fixed to include
+	// a shebang on its own.
+	return runLinter("/bin/sh", gazelleBin, "--mode=diff", filepath.Dir(file))
+}
+
+// checkGoFmt checks if the given file is formatted according to gofmt and, if not, prints a diff
+// detailing what's wrong with the file to stdout and returns an error.
+func checkGofmt(file string) error {
+	return runLinter(gofmtBin, "-d", "-e", "-s", file)
+}
+
+// checkGoLint checks if the given file passes golint checks and, if not, prints diagnostic messages
+// to stdout and returns an error.
+func checkGolint(file string) error {
+	// Lower confidence levels raise a per-file warning to remind about having a package-level
+	// docstring... but the warning is issued blindly without checking for the existing of this
+	// docstring in other packages.
+	minConfidenceFlag := "-min_confidence=0.3"
+
+	return runLinter(golintBin, minConfidenceFlag, file)
+}
+
+// checkAll runs all possible checks on a file.  Returns true if all checks pass, and false
+// otherwise.  Error details are dumped to stderr.
+func checkAll(file string) bool {
+	isBuildFile := filepath.Base(file) == "BUILD.bazel"
+
+	// If a file starts with an upper-case letter, assume it's supporting package documentation
+	// (all those files in the root directory) and avoid linting it.
+	isDocumentation := mustMatch(`^[A-Z]`, filepath.Base(file)) && !isBuildFile
+
+	log.Printf("Linting file %s", file)
+	ok := true
+
+	runCheck := func(checker func(string) error, file string) {
+		if err := checker(file); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %v\n", file, err)
+			ok = false
+		}
+	}
+
+	if !isBuildFile && !isDocumentation {
+		runCheck(checkLicense, file)
+	}
+
+	if isBuildFile {
+		runCheck(checkBuildifier, file)
+		runCheck(checkGazelle, file)
+	}
+
+	if filepath.Ext(file) == ".go" {
+		runCheck(checkGofmt, file)
+		runCheck(checkGolint, file)
+	}
+
+	return ok
+}
+
+// mustMatch returns true if the given regular expression matches the string.  The regular
+// expression is assumed to be valid.
+func mustMatch(pattern string, str string) bool {
+	matched, err := regexp.MatchString(pattern, str)
+	if err != nil {
+		panic("invalid regexp")
+	}
+	return matched
+}

--- a/admin/lint/checks.go
+++ b/admin/lint/checks.go
@@ -128,7 +128,7 @@ func checkAll(file string) bool {
 		}
 	}
 
-	if !isBuildFile && !isDocumentation {
+	if !isBuildFile && !isDocumentation && filepath.Base(file) != "settings.json.in" {
 		runCheck(checkLicense, file)
 	}
 

--- a/admin/lint/lint.go
+++ b/admin/lint/lint.go
@@ -1,0 +1,133 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// The lint binary ensures the source tree is correctly formatted.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// getWorkspaceDir finds the path to the workspace given a path to a WORKSPACE file (which could be
+// a symlink as staged by Bazel).  The returned path is absolute.
+func getWorkspaceDir(file string) (string, error) {
+	fileInfo, err := os.Lstat(file)
+	if err != nil {
+		return "", fmt.Errorf("cannot find %s: %v", file, err)
+	}
+
+	var dir string
+	if fileInfo.Mode()&os.ModeType == os.ModeSymlink {
+		realFile, err := os.Readlink(file)
+		if err != nil {
+			return "", fmt.Errorf("cannot read link %s: %v", file, err)
+		}
+		dir = filepath.Dir(realFile)
+	} else {
+		dir = filepath.Dir(file)
+	}
+
+	dir, err = filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("cannot convert %s to an absolute path: %v", dir, err)
+	}
+
+	// We have computed the real path to the workspace.  Now... let's make sure that's true by
+	// looking for a known file.
+	fileInfo, err = os.Stat(filepath.Join(dir, "README.md"))
+	if err != nil {
+		return "", fmt.Errorf("cannot find README.md in workspace %s: %v", dir, err)
+	}
+	if fileInfo.Mode()&os.ModeType != 0 {
+		return "", fmt.Errorf("workspace %s contents are not regular files", dir)
+	}
+
+	return dir, nil
+}
+
+// collectFiles scans the given directory recursively and returns the paths to all regular files
+// within it.
+func collectFiles(dir string) ([]string, error) {
+	files := make([]string, 0)
+
+	collector := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip hidden files as we don't need to run checks on them.  (This is not strictly
+		// true, but it's simpler this way for now and the risk is low given that the hidden
+		// files we have are trivial.)
+		if strings.HasPrefix(path, dir+"/.") {
+			return err
+		}
+
+		if info.Mode()&os.ModeType == 0 {
+			files = append(files, path)
+		}
+
+		return err
+	}
+
+	return files, filepath.Walk(dir, collector)
+}
+
+func main() {
+	verbose := flag.Bool("verbose", false, "Enables extra logging")
+	workspace := flag.String("workspace", "WORKSPACE", "Path to the WORKSPACE file where the source tree list; used to find source files (symlinks are followed) and to resolve relative paths to sources")
+	flag.Parse()
+
+	if *verbose {
+		log.SetOutput(os.Stderr)
+	} else {
+		log.SetOutput(ioutil.Discard)
+	}
+
+	workspaceDir, err := getWorkspaceDir(*workspace)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+		os.Exit(1)
+	}
+
+	files := flag.Args()
+	if len(files) == 0 {
+		log.Printf("Searching for source files in %s", workspaceDir)
+		allFiles, err := collectFiles(workspaceDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+			os.Exit(1)
+		}
+		files = allFiles
+	}
+
+	failed := false
+	for _, arg := range files {
+		file := arg
+		if !filepath.IsAbs(file) {
+			file = filepath.Join(workspaceDir, file)
+		}
+		if !checkAll(file) {
+			failed = true
+		}
+	}
+	if failed {
+		os.Exit(1)
+	}
+}

--- a/admin/pre-commit
+++ b/admin/pre-commit
@@ -1,0 +1,26 @@
+#! /bin/sh
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+exec 1>&2
+
+# Obtain the list of files from the index (i.e. the files to be committed).
+# From the list, resolve renames to their target.
+index_files="$(git status --porcelain --untracked-files=no \
+    | grep '^[MARC]' | cut -c 4- | sed -e 's,^.* -> ,,')"
+
+if [ -n "${index_files}" ]; then
+  echo "Linting changed files..."
+  bazel run //admin/lint -- ${index_files} || exit 1
+fi

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -46,8 +46,12 @@ do_gotools() {
       go test -v -timeout=600s github.com/bazelbuild/sandboxfs/integration
 }
 
+do_lint() {
+  bazel run //admin/lint -- --verbose
+}
+
 case "${DO}" in
-  bazel|gotools)
+  bazel|gotools|lint)
     "do_${DO}"
     ;;
 

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -15,16 +15,41 @@
 
 set -e -u -x
 
-go build -o ./sandboxfs github.com/bazelbuild/sandboxfs/cmd/sandboxfs
-
-SANDBOXFS="$(pwd)/sandboxfs" \
-    go test -v -timeout 600s github.com/bazelbuild/sandboxfs/integration
-
 rootenv=()
 rootenv+=(PATH="${PATH}")
-rootenv+=(SANDBOXFS="$(pwd)/sandboxfs")
 rootenv+=(UNPRIVILEGED_USER="${USER}")
 [ "${GOPATH-unset}" = unset ] || rootenv+=(GOPATH="${GOPATH}")
 [ "${GOROOT-unset}" = unset ] || rootenv+=(GOROOT="${GOROOT}")
-sudo -H "${rootenv[@]}" -s \
-    go test -v -timeout 600s github.com/bazelbuild/sandboxfs/integration
+readonly rootenv
+
+do_bazel() {
+  bazel build //cmd/sandboxfs
+
+  # TODO(jmmv): We disable Bazel's sandboxing because it denies our tests from
+  # using FUSE (e.g. accessing system-wide helper binaries).  Figure out a way
+  # to not require this.
+  bazel test --spawn_strategy=standalone --test_output=streamed //...
+  sudo -H "${rootenv[@]}" \
+      SANDBOXFS="$(pwd)/bazel-bin/cmd/sandboxfs/sandboxfs" -s \
+      ./bazel-bin/integration/go_default_test -test.v -test.timeout=600s
+}
+
+do_gotools() {
+  go build -o ./sandboxfs github.com/bazelbuild/sandboxfs/cmd/sandboxfs
+
+  SANDBOXFS="$(pwd)/sandboxfs" \
+      go test -v -timeout=600s github.com/bazelbuild/sandboxfs/integration
+  sudo -H "${rootenv[@]}" SANDBOXFS="$(pwd)/sandboxfs" -s \
+      go test -v -timeout=600s github.com/bazelbuild/sandboxfs/integration
+}
+
+case "${DO}" in
+  bazel|gotools)
+    "do_${DO}"
+    ;;
+
+  *)
+    echo "Unknown value for DO variable" 1>&2
+    exit 1
+    ;;
+esac

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -23,20 +23,23 @@ rootenv+=(UNPRIVILEGED_USER="${USER}")
 readonly rootenv
 
 do_bazel() {
-  bazel build //cmd/sandboxfs
+  bazel run //admin/install -- --prefix="$(pwd)/local"
 
   # TODO(jmmv): We disable Bazel's sandboxing because it denies our tests from
   # using FUSE (e.g. accessing system-wide helper binaries).  Figure out a way
   # to not require this.
   bazel test --spawn_strategy=standalone --test_output=streamed //...
-  sudo -H "${rootenv[@]}" \
-      SANDBOXFS="$(pwd)/bazel-bin/cmd/sandboxfs/sandboxfs" -s \
+  sudo -H "${rootenv[@]}" SANDBOXFS="$(pwd)/local/bin/sandboxfs" -s \
       ./bazel-bin/integration/go_default_test -test.v -test.timeout=600s
+
+  # Make sure we can install as root as documented in INSTALL.md.
+  sudo ./bazel-bin/admin/install/install --prefix="$(pwd)/local-root"
 }
 
 do_gotools() {
   go build -o ./sandboxfs github.com/bazelbuild/sandboxfs/cmd/sandboxfs
 
+  go test -v -timeout=600s github.com/bazelbuild/sandboxfs/internal/shell
   SANDBOXFS="$(pwd)/sandboxfs" \
       go test -v -timeout=600s github.com/bazelbuild/sandboxfs/integration
   sudo -H "${rootenv[@]}" SANDBOXFS="$(pwd)/sandboxfs" -s \

--- a/admin/travis-install.sh
+++ b/admin/travis-install.sh
@@ -66,4 +66,8 @@ case "${DO}" in
   gotools)
     install_fuse
     ;;
+
+  lint)
+    install_bazel
+    ;;
 esac

--- a/admin/travis-install.sh
+++ b/admin/travis-install.sh
@@ -15,22 +15,55 @@
 
 set -e -u
 
-case "${TRAVIS_OS_NAME}" in
-  linux)
-    sudo apt-get update
-    sudo apt-get install -qq fuse libfuse-dev pkg-config user-mode-linux
+install_bazel() {
+  local osname
+  case "${TRAVIS_OS_NAME}" in
+    osx) osname=darwin ;;
+    *) osname="${TRAVIS_OS_NAME}" ;;
+  esac
 
-    sudo usermod -a -G fuse "${USER}"
+  local github="https://github.com/bazelbuild/bazel/releases/download/0.7.0"
+  local url="${github}/bazel-0.7.0-installer-${osname}-x86_64.sh"
+  wget -O install-bazel.sh "${url}"
+  chmod +x install-bazel.sh
+  ./install-bazel.sh --user
+  rm -f install-bazel.sh
+}
 
-    sudo /bin/sh -c 'echo user_allow_other >>/etc/fuse.conf'
-    sudo chmod 644 /etc/fuse.conf
+install_fuse() {
+  case "${TRAVIS_OS_NAME}" in
+    linux)
+      sudo apt-get update
+      sudo apt-get install -qq fuse libfuse-dev pkg-config user-mode-linux
+
+      sudo usermod -a -G fuse "${USER}"
+
+      sudo /bin/sh -c 'echo user_allow_other >>/etc/fuse.conf'
+      sudo chmod 644 /etc/fuse.conf
+      ;;
+
+    osx)
+      brew update
+      brew cask install osxfuse
+
+      sudo /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse
+      sudo sysctl -w vfs.generic.osxfuse.tunables.allow_other=1
+      ;;
+
+    *)
+      echo "Don't know how to install FUSE for OS ${TRAVIS_OS_NAME}" 1>&2
+      exit 1
+      ;;
+  esac
+}
+
+case "${DO}" in
+  bazel)
+    install_bazel
+    install_fuse
     ;;
 
-  osx)
-    brew update
-    brew cask install osxfuse
-
-    sudo /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse
-    sudo sysctl -w vfs.generic.osxfuse.tunables.allow_other=1
+  gotools)
+    install_fuse
     ;;
 esac

--- a/cmd/sandboxfs/BUILD.bazel
+++ b/cmd/sandboxfs/BUILD.bazel
@@ -23,3 +23,9 @@ go_binary(
     library = ":go_default_library",
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "manpage",
+    srcs = ["sandboxfs.1"],
+    visibility = ["//admin/install:__pkg__"],
+)

--- a/cmd/sandboxfs/BUILD.bazel
+++ b/cmd/sandboxfs/BUILD.bazel
@@ -1,0 +1,25 @@
+licenses(["notice"])  # Apache License 2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "errors.go",
+        "profiling.go",
+        "sandboxfs.go",
+    ],
+    importpath = "github.com/bazelbuild/sandboxfs/cmd/sandboxfs",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//internal/sandbox:go_default_library",
+        "@org_bazil_fuse//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "sandboxfs",
+    importpath = "github.com/bazelbuild/sandboxfs/cmd/sandboxfs",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/configure
+++ b/configure
@@ -1,0 +1,43 @@
+#! /bin/sh
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+readonly PROGNAME="${0##*/}"
+readonly SRCDIR="$(cd "$(dirname "${0}")" && pwd -P)"
+
+info() {
+  echo "${PROGNAME}: I: ${@}" 1>&2
+}
+
+# Installs git hooks into the git directory provided in git_dir.
+setup_git() {
+  local git_dir="${1}"; shift
+
+  cd "${git_dir}/hooks"
+  for hook in ../../admin/pre-commit; do
+    info "Installing git hook ${hook##*/}"
+    ln -s -f "${hook}" .
+  done
+  cd - >/dev/null 2>&1
+}
+
+main() {
+  cd "${SRCDIR}"
+
+  [ -d .git ] && setup_git .git
+}
+
+main "${@}"

--- a/configure
+++ b/configure
@@ -13,10 +13,26 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+# This is a shell script and not a Go program because we have to run
+# bazel-gopath, and the bazel-gopath tool invokes Bazel on its own.  So, if
+# this were a Go program and we wanted to tell users to invoke it with "bazel
+# run" as we do for all other tools, bazel-gopath would get stuck because Bazel
+# can only run one command at a time.  It's easier for now to just keep this as
+# a shell-script so that it's impossible to run it from within Bazel.
+#
+# TODO(jmmv): Convert to a Go program once bazel-gopath is fixed to not need
+# to run Bazel.  (E.g. it could be made to read query outputs from a dependency
+# and then have a Bazel genquery rule to supply such data as a dependency.)
+
 set -e
 
 readonly PROGNAME="${0##*/}"
 readonly SRCDIR="$(cd "$(dirname "${0}")" && pwd -P)"
+
+err() {
+  echo "${PROGNAME}: E: ${@}" 1>&2
+  exit 1
+}
 
 info() {
   echo "${PROGNAME}: I: ${@}" 1>&2
@@ -34,10 +50,40 @@ setup_git() {
   cd - >/dev/null 2>&1
 }
 
+setup_vscode() {
+  bazel build @bazel_gopath//:bazel-gopath
+
+  # Populate bazel-sandboxfs/ with symlinks to all source files, required later
+  # on as targets for the generated gopath.
+  bazel build //cmd/sandboxfs:sandboxfs
+
+  ./bazel-bin/external/bazel_gopath/bazel-gopath --workspace="$(pwd)"
+
+  {
+    echo '// AUTOMATICALLY GENERATED!!!'
+    echo '// EDIT settings.json.in INSTEAD'
+    sed \
+        -e "s,__GOPATH__,$(pwd)/.gopath,g" \
+        -e "s,__GOROOT__,$(pwd)/bazel-sandboxfs/external/go_sdk,g" \
+        -e "s,__TOOLS_GOPATH__,$(pwd)/.gopath-tools,g" \
+        .vscode/settings.json.in
+  } >.vscode/settings.json
+}
+
 main() {
   cd "${SRCDIR}"
 
+  local enable_vscode=no
+  for arg in "${@}"; do
+    case "${arg}" in
+      --enable-vscode) enable_vscode=yes ;;
+      *) err "Unknown argument ${arg}" ;;
+    esac
+  done
+
   [ -d .git ] && setup_git .git
+
+  [ "${enable_vscode}" = no ] || setup_vscode
 }
 
 main "${@}"

--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -1,0 +1,38 @@
+licenses(["notice"])  # Apache License 2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["doc.go"],
+    importpath = "github.com/bazelbuild/sandboxfs/integration",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "large",
+    srcs = [
+        "cli_test.go",
+        "debug_test.go",
+        "layout_test.go",
+        "nesting_test.go",
+        "options_test.go",
+        "profiling_test.go",
+        "read_only_test.go",
+        "read_write_test.go",
+        "reconfiguration_test.go",
+        "signal_test.go",
+    ],
+    data = [
+        "//cmd/sandboxfs",
+    ],
+    importpath = "github.com/bazelbuild/sandboxfs/integration",
+    library = ":go_default_library",
+    deps = [
+        "//integration/utils:go_default_library",
+        "//internal/sandbox:go_default_library",
+        "@org_bazil_fuse//:go_default_library",
+        "@org_golang_x_net//context:go_default_library",
+    ],
+)

--- a/integration/read_write_test.go
+++ b/integration/read_write_test.go
@@ -824,8 +824,8 @@ func TestReadWrite_FutimesOnDeletedNode(t *testing.T) {
 			defer syscall.Close(fd)
 
 			tv := []syscall.Timeval{
-				syscall.Timeval{Sec: int64(someAtime.Unix())},
-				syscall.Timeval{Sec: int64(someMtime.Unix())},
+				{Sec: int64(someAtime.Unix())},
+				{Sec: int64(someMtime.Unix())},
 			}
 			if err := syscall.Futimes(fd, tv); err != nil {
 				t.Fatalf("Fchown failed on deleted entry: %v", err)

--- a/integration/reconfiguration_test.go
+++ b/integration/reconfiguration_test.go
@@ -72,9 +72,9 @@ func doReconfigurationTest(t *testing.T, state *utils.MountState, input io.Write
 
 	utils.MustMkdirAll(t, state.RootPath("a/a"), 0755)
 	config := jsonConfig([]sandbox.MappingSpec{
-		sandbox.MappingSpec{Mapping: "/ro", Target: state.RootPath("a/a"), Writable: false},
-		sandbox.MappingSpec{Mapping: "/", Target: state.RootPath(), Writable: true},
-		sandbox.MappingSpec{Mapping: "/ro/rw", Target: state.RootPath(), Writable: true},
+		{Mapping: "/ro", Target: state.RootPath("a/a"), Writable: false},
+		{Mapping: "/", Target: state.RootPath(), Writable: true},
+		{Mapping: "/ro/rw", Target: state.RootPath(), Writable: true},
 	})
 	if err := reconfigure(input, output, config); err != nil {
 		t.Fatal(err)
@@ -100,7 +100,7 @@ func doReconfigurationTest(t *testing.T, state *utils.MountState, input io.Write
 	}
 
 	config = jsonConfig([]sandbox.MappingSpec{
-		sandbox.MappingSpec{Mapping: "/rw/dir", Target: state.RootPath(), Writable: true},
+		{Mapping: "/rw/dir", Target: state.RootPath(), Writable: true},
 	})
 	if err := reconfigure(input, output, config); err != nil {
 		t.Fatal(err)
@@ -193,8 +193,8 @@ func TestReconfiguration_InodesAreStableForSameUnderlyingFiles(t *testing.T) {
 	wantInodes := make(map[string]uint64)
 
 	firstConfig := jsonConfig([]sandbox.MappingSpec{
-		sandbox.MappingSpec{Mapping: "/dir1", Target: state.RootPath("dir1"), Writable: false},
-		sandbox.MappingSpec{Mapping: "/dir3", Target: state.RootPath("dir3"), Writable: false},
+		{Mapping: "/dir1", Target: state.RootPath("dir1"), Writable: false},
+		{Mapping: "/dir3", Target: state.RootPath("dir3"), Writable: false},
 	})
 	if err := reconfigure(state.Stdin, output, firstConfig); err != nil {
 		t.Fatalf("First configuration failed: %v", err)
@@ -205,7 +205,7 @@ func TestReconfiguration_InodesAreStableForSameUnderlyingFiles(t *testing.T) {
 	wantInodes["dir3/file"] = inodeOf(state.MountPath("dir3/file"))
 
 	secondConfig := jsonConfig([]sandbox.MappingSpec{
-		sandbox.MappingSpec{Mapping: "/dir2", Target: state.RootPath("dir2"), Writable: false},
+		{Mapping: "/dir2", Target: state.RootPath("dir2"), Writable: false},
 	})
 	if err := reconfigure(state.Stdin, output, secondConfig); err != nil {
 		t.Fatalf("Failed to replace all mappings with new configuration: %v", err)
@@ -243,7 +243,7 @@ func TestReconfiguration_WritableNodesAreDifferent(t *testing.T) {
 	utils.MustMkdirAll(t, state.RootPath("dir1"), 0755)
 
 	config := jsonConfig([]sandbox.MappingSpec{
-		sandbox.MappingSpec{Mapping: "/dir1", Target: state.RootPath("dir1"), Writable: true},
+		{Mapping: "/dir1", Target: state.RootPath("dir1"), Writable: true},
 	})
 	if err := reconfigure(state.Stdin, output, config); err != nil {
 		t.Fatal(err)
@@ -254,7 +254,7 @@ func TestReconfiguration_WritableNodesAreDifferent(t *testing.T) {
 	}
 
 	config = jsonConfig([]sandbox.MappingSpec{
-		sandbox.MappingSpec{Mapping: "/dir1", Target: state.RootPath("dir1"), Writable: false},
+		{Mapping: "/dir1", Target: state.RootPath("dir1"), Writable: false},
 	})
 	if err := reconfigure(state.Stdin, output, config); err != nil {
 		t.Fatal(err)
@@ -306,7 +306,7 @@ func TestReconfiguration_FileSystemStillWorksAfterInputEOF(t *testing.T) {
 
 	utils.MustMkdirAll(t, state.RootPath("dir"), 0755)
 	config := jsonConfig([]sandbox.MappingSpec{
-		sandbox.MappingSpec{Mapping: "/dir", Target: state.RootPath("dir"), Writable: true},
+		{Mapping: "/dir", Target: state.RootPath("dir"), Writable: true},
 	})
 	if err := reconfigure(state.Stdin, output, config); err != nil {
 		t.Fatal(err)
@@ -448,7 +448,7 @@ func TestReconfiguration_InvalidationsRaceWithWrites(t *testing.T) {
 
 	utils.MustMkdirAll(t, state.RootPath("dir"), 0755)
 	config := jsonConfig([]sandbox.MappingSpec{
-		sandbox.MappingSpec{Mapping: "/dir", Target: state.RootPath("dir"), Writable: false},
+		{Mapping: "/dir", Target: state.RootPath("dir"), Writable: false},
 	})
 
 	nEntries := 2000

--- a/integration/utils/BUILD.bazel
+++ b/integration/utils/BUILD.bazel
@@ -1,0 +1,19 @@
+licenses(["notice"])  # Apache License 2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "checks.go",
+        "doc.go",
+        "exec.go",
+        "user.go",
+    ],
+    importpath = "github.com/bazelbuild/sandboxfs/integration/utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_bazil_fuse//:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)

--- a/integration/utils/exec.go
+++ b/integration/utils/exec.go
@@ -32,6 +32,10 @@ import (
 )
 
 const (
+	// Path to the sandboxfs as staged by Bazel.  Used unless SANDBOXFS is defined in the
+	// environment.
+	sandboxfsDep = "../cmd/sandboxfs/sandboxfs"
+
 	// Maximum amount of time to wait for sandboxfs to come up and start serving.
 	startupDeadlineSeconds = 10
 
@@ -43,7 +47,10 @@ const (
 func sandboxfsBinary() (string, error) {
 	bin := os.Getenv("SANDBOXFS")
 	if bin == "" {
-		return "", fmt.Errorf("SANDBOXFS not defined in environment")
+		if _, err := os.Lstat(sandboxfsDep); err != nil {
+			return "", fmt.Errorf("SANDBOXFS not defined in environment")
+		}
+		bin = sandboxfsDep
 	}
 	return bin, nil
 }

--- a/internal/sandbox/BUILD.bazel
+++ b/internal/sandbox/BUILD.bazel
@@ -1,0 +1,32 @@
+licenses(["notice"])  # Apache License 2.0
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "mapped_dir.go",
+        "mapped_file.go",
+        "mapped_symlink.go",
+        "node.go",
+        "root.go",
+        "sandbox.go",
+        "scaffold_dir.go",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            "node_darwin.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "node_linux.go",
+        ],
+        "//conditions:default": [],
+    }),
+    importpath = "github.com/bazelbuild/sandboxfs/internal/sandbox",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@org_bazil_fuse//:go_default_library",
+        "@org_bazil_fuse//fs:go_default_library",
+        "@org_golang_x_net//context:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)

--- a/internal/shell/BUILD.bazel
+++ b/internal/shell/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["shell.go"],
+    importpath = "github.com/bazelbuild/sandboxfs/internal/shell",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["shell_test.go"],
+    importpath = "github.com/bazelbuild/sandboxfs/internal/shell",
+    library = ":go_default_library",
+)

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -16,12 +16,30 @@
 package shell
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"regexp"
 	"syscall"
 )
+
+// Grep checks whether the given file's contents match the pattern.
+func Grep(pattern string, file string) (bool, error) {
+	input, err := os.OpenFile(file, os.O_RDONLY, 0)
+	if err != nil {
+		return false, fmt.Errorf("failed to open %s for read: %v", file, err)
+	}
+	defer input.Close()
+
+	matched, err := regexp.MatchReader(pattern, bufio.NewReader(input))
+	if err != nil {
+		return false, fmt.Errorf("failed to search for %s in %s: %v", pattern, file, err)
+	}
+
+	return matched, nil
+}
 
 // Install copies a file and sets desired permissions on the destination.  The permissions are set
 // exactly as specified, without respecting the process' umask.

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -1,0 +1,61 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// Package shell contains utilities that mimic external command-line utilities.
+package shell
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"syscall"
+)
+
+// Install copies a file and sets desired permissions on the destination.  The permissions are set
+// exactly as specified, without respecting the process' umask.
+func Install(source string, target string, mode os.FileMode) error {
+	log.Printf("%s -> %s (mode %v)", source, target, mode)
+
+	input, err := os.OpenFile(source, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("cannot open %s for read: %v", source, err)
+	}
+	defer input.Close()
+
+	// Clear the umask so that the possible file creation or the subsequent chmod we perform
+	// below all respect the mode given by the user.
+	oldmask := syscall.Umask(0)
+	syscall.Umask(oldmask)
+
+	output, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("cannot open %s for write: %v", target, err)
+	}
+	defer output.Close()
+
+	// The OpenFile above may have truncated an existing file so we need to explicitly set the
+	// permissions we want on the file to cover that case.
+	if err := os.Chmod(target, mode); err != nil {
+		os.Remove(target)
+		return fmt.Errorf("failed to set permissions of %s to %v: %v", target, mode, err)
+	}
+
+	if _, err := io.Copy(output, input); err != nil {
+		os.Remove(target)
+		return fmt.Errorf("data copy failed from %s to %s: %v", source, target, err)
+	}
+
+	return nil
+}

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -1,0 +1,116 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package shell
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"syscall"
+	"testing"
+)
+
+// checkError is a helper function for tests that want to check that a specific error is raised,
+// and does so by ensuring that the given error matches the given regexp.
+func checkError(original error, pattern string) error {
+	if original == nil {
+		return fmt.Errorf("want failure that matches %s, got none", pattern)
+	}
+	match, err := regexp.MatchString(pattern, original.Error())
+	if err != nil {
+		return fmt.Errorf("bad regexp %s: this is a bug in the test", pattern)
+	}
+	if !match {
+		return fmt.Errorf("want failure that matches %s, got %v", pattern, original)
+	}
+	return nil
+}
+
+func TestInstall(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	contents := "original text"
+	goodSource := filepath.Join(tempDir, "file1")
+	if err := ioutil.WriteFile(goodSource, []byte(contents), 0444); err != nil {
+		t.Fatalf("Failed to create test file %s: %v", goodSource, err)
+	}
+
+	badSource := filepath.Join(tempDir, "missing")
+
+	newTarget := filepath.Join(tempDir, "file2")
+
+	existingTarget := filepath.Join(tempDir, "file3")
+	if err := ioutil.WriteFile(existingTarget, []byte("old text"), 0600); err != nil {
+		t.Fatalf("Failed to create test file %s: %v", existingTarget, err)
+	}
+
+	badTarget := filepath.Join(tempDir, "missing-subdir/file")
+
+	// Set a rather unusual umask throughout the test to ensure that our Install function does
+	// honor the permissions we pass it on any created files.
+	oldmask := syscall.Umask(0047)
+	defer syscall.Umask(oldmask)
+
+	testData := []struct {
+		name string
+
+		source           string
+		target           string
+		mode             os.FileMode
+		wantErrorPattern string
+	}{
+		{"NewTarget", goodSource, newTarget, 0644, ""},
+		{"ReplaceTarget", goodSource, existingTarget, 0400, ""},
+
+		{"CannotOpenSource", badSource, "", 0000, "cannot open " + badSource + " for read"},
+		{"CannotOpenTarget", goodSource, badTarget, 0000, "cannot open " + badTarget + " for write"},
+	}
+	for _, d := range testData {
+		t.Run(d.name, func(t *testing.T) {
+			err := Install(d.source, d.target, d.mode)
+			if d.wantErrorPattern == "" {
+				if err != nil {
+					t.Fatalf("Install failed: %v", err)
+				}
+
+				fileInfo, err := os.Lstat(d.target)
+				if err != nil {
+					t.Fatalf("Cannot stat created target %s: %v", d.target, err)
+				}
+				if fileInfo.Mode() != d.mode {
+					t.Errorf("Installed file permissions are wrong: got %v, want %v", fileInfo.Mode(), d.mode)
+				}
+
+				readContents, err := ioutil.ReadFile(d.target)
+				if err != nil {
+					t.Fatalf("Cannot read created target %s: %v", d.target, err)
+				}
+				if string(readContents) != contents {
+					t.Errorf("Installed file does not match original file: got %s, want %s", readContents, contents)
+				}
+			} else {
+				if err := checkError(err, d.wantErrorPattern); err != nil {
+					t.Fatal(err) // Message returned by helper is sufficient.
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This set of commits adds a Bazel build for sandboxfs and then uses that to add source code linting (with pre-commit checks) and IDE integration with VSCode.

These commits are "clean" on their own, so they shall be merged without squashing.