### PR TITLE
Fix sample sandboxfs invocation

### DIFF
--- a/cmd/sandboxfs/sandboxfs.1
+++ b/cmd/sandboxfs/sandboxfs.1
@@ -296,6 +296,7 @@ file system but clears
 to point into a sandbox-specific writable directory:
 .Bd -literal -indent
 sandboxfs \\
+    static \\
     --read_only_mapping=/:/ \\
     --read_write_mapping=/tmp:/tmp/fresh-tmp \\
     /mnt


### PR DESCRIPTION
The invocation was missing the command name to invoke, which in this
case ought to be "static".

Fixes #8.