### PR TITLE
Implement a --version flag

### DIFF
--- a/.vscode/settings.json.in
+++ b/.vscode/settings.json.in
@@ -5,6 +5,7 @@
   "editor.wordWrapColumn": 80,
 
   "files.associations": {
+    "sandboxfs.1": "troff",
     "settings.json.in": "json"
   },
   "files.exclude": {
@@ -34,5 +35,13 @@
   "[makefile]": {
     "editor.insertSpaces": false,
     "editor.tabSize": 8
+  },
+
+  "[markdown]": {
+    "editor.quickSuggestions": false
+  },
+
+  "[troff]": {
+    "editor.quickSuggestions": false
   }
 }

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,11 @@ licenses(["notice"])  # Apache License 2.0
 
 exports_files(["WORKSPACE"])
 
+exports_files(
+    ["package.bzl"],
+    visibility = ["//cmd/sandboxfs:__pkg__"],
+)
+
 filegroup(
     name = "distdocs",
     srcs = [

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,12 +43,16 @@ To get started:
 
 ## From sources with the Go tools
 
-You can also build and install sandboxfs from this Git repository using the
-standard Go tools as follows:
+You can also build sandboxfs from this Git repository using the standard Go
+tools as follows:
 
     go get github.com/bazelbuild/sandboxfs/cmd/sandboxfs
     go build github.com/bazelbuild/sandboxfs/cmd/sandboxfs
 
-This is not recommended because this mechanism does not provide a way to
+This is not supported because this mechanism does not provide a way to
 install the built product.  (Yes, `go install` does install the binary but does
 not handle other support files such as documentation.)
+
+Furthermore, this mechanism does not bundle build information into the final
+binary, which means the final binary **cannot be shipped** and may not
+interact well with other tools.

--- a/admin/lint/checks.go
+++ b/admin/lint/checks.go
@@ -112,7 +112,7 @@ func checkGolint(file string) error {
 // checkAll runs all possible checks on a file.  Returns true if all checks pass, and false
 // otherwise.  Error details are dumped to stderr.
 func checkAll(file string) bool {
-	isBuildFile := filepath.Base(file) == "BUILD.bazel"
+	isBuildFile := filepath.Base(file) == "BUILD.bazel" || filepath.Ext(file) == ".bzl"
 
 	// If a file starts with an upper-case letter, assume it's supporting package documentation
 	// (all those files in the root directory) and avoid linting it.

--- a/cmd/sandboxfs/BUILD.bazel
+++ b/cmd/sandboxfs/BUILD.bazel
@@ -1,5 +1,6 @@
 licenses(["notice"])  # Apache License 2.0
 
+load("//:package.bzl", "PACKAGE_VERSION")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -22,6 +23,9 @@ go_binary(
     importpath = "github.com/bazelbuild/sandboxfs/cmd/sandboxfs",
     library = ":go_default_library",
     visibility = ["//visibility:public"],
+    x_defs = {
+        "main.packageVersion": PACKAGE_VERSION,
+    },
 )
 
 filegroup(

--- a/cmd/sandboxfs/sandboxfs.1
+++ b/cmd/sandboxfs/sandboxfs.1
@@ -11,7 +11,7 @@
 .\" WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 .\" License for the specific language governing permissions and limitations
 .\" under the License.
-.Dd October 30, 2017
+.Dd November 29, 2017
 .Dt SANDBOXFS 1
 .Os
 .Sh NAME
@@ -25,6 +25,7 @@
 .Op Fl -listen_address Ar host:port
 .Op Fl -help
 .Op Fl -mem_profile Ar file
+.Op Fl -version
 .Op Fl -volume_name Ar volume_name
 dynamic
 .Op Fl -help
@@ -113,6 +114,7 @@ and
 because only one profiling mechanism can be enabled at once.
 .It Fl -help
 Prints global help details and exits.
+Specifying this flag causes all other valid flags and arguments to be ignored.
 .It Fl -mem_profile Ar file
 Enables memory profiling and writes a profile to the given
 .Ar file
@@ -121,6 +123,22 @@ on exit.
 This option is incompatible with
 .Fl -listen_address
 because only one profiling mechanism can be enabled at once.
+.It Fl -version
+Prints version information and exits.
+Specifying this flag causes all other valid flags and arguments to be ignored
+except for
+.Fl -help ,
+which has priority over this one.
+.Pp
+The first line printed to stdout is machine parseable and follows the following
+structure:
+.Bd -literal -indent
+sandboxfs MAJOR.MINOR[.ADDITIONAL OPTIONAL QUALIFIERS]
+.Ed
+.Pp
+Programs automating invocations of
+.Nm
+can use this information to determine the correct command-line syntax to use.
 .It Fl -volume_name Ar volume_name
 Specifies the name of the mounted volume, which is used by some operating
 systems (such as macOS) to display a volume label in the system UI.

--- a/cmd/sandboxfs/sandboxfs.go
+++ b/cmd/sandboxfs/sandboxfs.go
@@ -33,6 +33,14 @@ import (
 	"github.com/bazelbuild/sandboxfs/internal/sandbox"
 )
 
+var (
+	// packageVersion contains the textual version number of this package.
+	//
+	// The value here is populated by the build system.  The placeholder denotes that
+	// a build that misses to include this detail should not be shipped to users.
+	packageVersion = "0.0 (BINARY NOT FOR RELEASE)"
+)
+
 // allowFlag holds the value of and parses a flag that controls who has access to the file system.
 type allowFlag struct {
 	// Option is the FUSE mount option to pass to the mount operation, or nil if not applicable.
@@ -354,6 +362,7 @@ func safeMain(progname string, args []string) error {
 	help := flags.Bool("help", false, "print the usage information and exit")
 	listenAddress := flags.String("listen_address", "", "enable HTTP server on the given address and expose pprof data")
 	memProfile := flags.String("mem_profile", "", "write a memory profile to the given file on exit")
+	version := flags.Bool("version", true, "show version information and exit")
 	volumeName := flags.String("volume_name", "sandbox", "name for the sandboxfs volume")
 
 	if err := flags.Parse(args); err != nil {
@@ -368,6 +377,11 @@ Subcommands:
 Flags:
 `, progname)
 		usage(os.Stdout, flags)
+		return nil
+	}
+
+	if *version {
+		fmt.Fprintf(os.Stdout, "sandboxfs %s\n", packageVersion)
 		return nil
 	}
 

--- a/cmd/sandboxfs/sandboxfs.go
+++ b/cmd/sandboxfs/sandboxfs.go
@@ -362,7 +362,7 @@ func safeMain(progname string, args []string) error {
 	help := flags.Bool("help", false, "print the usage information and exit")
 	listenAddress := flags.String("listen_address", "", "enable HTTP server on the given address and expose pprof data")
 	memProfile := flags.String("mem_profile", "", "write a memory profile to the given file on exit")
-	version := flags.Bool("version", true, "show version information and exit")
+	version := flags.Bool("version", false, "show version information and exit")
 	volumeName := flags.String("volume_name", "sandbox", "name for the sandboxfs volume")
 
 	if err := flags.Parse(args); err != nil {

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// versionPattern contains a pattern to match the output of sandboxfs --version.
-	versionPattern = `sandboxfs [0-9]+.[0-9]+`
+	versionPattern = `sandboxfs [0-9]+\.[0-9]+`
 )
 
 func TestCli_Help(t *testing.T) {
@@ -122,7 +122,7 @@ func TestCli_VersionNotForRelease(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if utils.MatchesRegexp("NOT.*FOR.*RELEASE", stdout) {
+	if utils.MatchesRegexp(`NOT.*FOR.*RELEASE`, stdout) {
 		t.Errorf("Got %s; binary not built for release", stdout)
 	}
 }

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -44,6 +44,8 @@ Flags:
     	enable HTTP server on the given address and expose pprof data
   -mem_profile string
     	write a memory profile to the given file on exit
+  -version
+    	show version information and exit
   -volume_name string
     	name for the sandboxfs volume (default "sandbox")
 `

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -16,6 +16,7 @@ package integration
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/bazelbuild/sandboxfs/integration/utils"
@@ -110,7 +111,17 @@ func TestCli_Version(t *testing.T) {
 	if len(stderr) > 0 {
 		t.Errorf("Got %s; want stderr to be empty", stderr)
 	}
+}
 
+func TestCli_VersionNotForRelease(t *testing.T) {
+	if os.Getenv("SKIP_NOT_FOR_RELEASE_TEST") == "yes" {
+		t.Skipf("Skipped because SKIP_NOT_FOR_RELEASE_TEST is 'yes' in the environment, which means we knowingly built a non-release binary")
+	}
+
+	stdout, _, err := utils.RunAndWait(0, "--version")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if utils.MatchesRegexp("NOT.*FOR.*RELEASE", stdout) {
 		t.Errorf("Got %s; binary not built for release", stdout)
 	}

--- a/package.bzl
+++ b/package.bzl
@@ -1,0 +1,1 @@
+PACKAGE_VERSION = "0.1"


### PR DESCRIPTION
Add a version number to sandboxfs and implement a --version flag to dump
it to stdout.  This will be used by Bazel to determine which protocol to
use to communicate with the sandboxfs daemon, allowing us to change the
command-line interface in the future.

Personally, I don't like --version being a flag: given that we have a
subcommand-based interface, this should really be a "version" command.
However, we already have --help so --version doesn't hurt much more.
And I have ideas to kill the subcommand-based interface, which would
homogenize things.