### PR TITLE
Use Bazel 0.9.0 and Go rules 0.9.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,7 @@ To get started:
     build the final binary, and build the installation tool.
 
 1.  To copy all binary and data files to the default destination of
-    `/usr/local`, run `./bazel-bin/admin/install/install`.
+    `/usr/local`, run `./bazel-bin/admin/install/*/install`.
 
     *   You will (most likely) need superuser permissions to install
         under `/usr/local`, so run the previous command with `sudo`.
@@ -37,8 +37,15 @@ To get started:
         Don't run Bazel as root.  Instead, just build the installation tool
         first and run it separately, as described above.
 
+    *   The reason the above command includes a `*` in it is because Bazel
+        currently writes built Go binaries in a configuration-specific
+        location.  We can't guess what the name is upfront, so you must
+        dynamically look it up.  See
+        <https://github.com/bazelbuild/rules_go/issues/1239> if this annoys
+        you.
+
     *   If you want to install sandboxfs under a custom prefix, run
-        `./bazel-bin/admin/install/install --prefix=/path/to/prefix`
+        `./bazel-bin/admin/install/*/install --prefix=/path/to/prefix`
         instead.
 
 ## From sources with the Go tools

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,8 @@ workspace(name = "sandboxfs")
 
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.7.0/rules_go-0.7.0.tar.gz",
-    sha256 = "91fca9cf860a1476abdc185a5f675b641b60d3acf0596679a27b580af60bf19c",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.9.0/rules_go-0.9.0.tar.gz",
+    sha256 = "4d8d6244320dd751590f9100cf39fd7a4b75cd901e1f3ffdfd6f048328883695",
 )
 
 # TODO(jmmv): Drop in favor of a new rules_go release once the commit below is
@@ -14,12 +14,20 @@ git_repository(
     commit = "dd3c631c31c8d4e3b5bcffc4b66e8c092172ed89",
 )
 
+http_archive(
+    name = "bazel_gazelle",
+    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.9/bazel-gazelle-0.9.tar.gz",
+    sha256 = "0103991d994db55b3b5d7b06336f8ae355739635e0c2379dea16b8213ea5a223",
+)
+
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_register_toolchains",
     "go_repository",
     "go_rules_dependencies",
 )
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 go_register_toolchains(go_version = "host")
 
@@ -52,4 +60,5 @@ go_repository(
     commit = "4b45465282a4624cf39876842a017334f13b8aff",
 )
 
+gazelle_dependencies()
 go_rules_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,6 +6,14 @@ http_archive(
     sha256 = "91fca9cf860a1476abdc185a5f675b641b60d3acf0596679a27b580af60bf19c",
 )
 
+# TODO(jmmv): Drop in favor of a new rules_go release once the commit below is
+# part of one.
+git_repository(
+    name = "com_github_bazelbuild_rules_go",
+    remote = "https://github.com/bazelbuild/rules_go.git",
+    commit = "dd3c631c31c8d4e3b5bcffc4b66e8c092172ed89",
+)
+
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_register_toolchains",

--- a/admin/BUILD.bazel
+++ b/admin/BUILD.bazel
@@ -1,6 +1,6 @@
 licenses(["notice"])  # Apache License 2.0
 
-load("@io_bazel_rules_go//go:def.bzl", "gazelle")
+load("@bazel_gazelle//:def.bzl", "gazelle")
 
 gazelle(
     name = "gazelle",

--- a/admin/install/BUILD.bazel
+++ b/admin/install/BUILD.bazel
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache License 2.0
+
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
@@ -5,7 +7,10 @@ go_library(
     srcs = ["install.go"],
     importpath = "github.com/bazelbuild/sandboxfs/admin/install",
     visibility = ["//visibility:private"],
-    deps = ["//internal/shell:go_default_library"],
+    deps = [
+        "//internal/shell:go_default_library",
+        "@com_github_bazelbuild_rules_go//go/tools/bazel:go_default_library",
+    ],
 )
 
 go_binary(

--- a/admin/install/BUILD.bazel
+++ b/admin/install/BUILD.bazel
@@ -20,7 +20,7 @@ go_binary(
         "//cmd/sandboxfs",
         "//cmd/sandboxfs:manpage",
     ],
+    embed = [":go_default_library"],
     importpath = "github.com/bazelbuild/sandboxfs/admin/install",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
 )

--- a/admin/lint/BUILD.bazel
+++ b/admin/lint/BUILD.bazel
@@ -1,11 +1,6 @@
-load("@io_bazel_rules_go//go:def.bzl", "gazelle", "go_binary", "go_library")
+licenses(["notice"])  # Apache License 2.0
 
-# TODO(jmmv): Remove this duplicate rule from //admin when the gazelle rule
-# supports a visibility attribute.
-gazelle(
-    name = "gazelle",
-    prefix = "github.com/bazelbuild/sandboxfs",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -15,17 +10,20 @@ go_library(
     ],
     importpath = "github.com/bazelbuild/sandboxfs/admin/lint",
     visibility = ["//visibility:private"],
-    deps = ["//internal/shell:go_default_library"],
+    deps = [
+        "//internal/shell:go_default_library",
+        "@com_github_bazelbuild_rules_go//go/tools/bazel:go_default_library",
+    ],
 )
 
 go_binary(
     name = "lint",
     data = [
-        ":gazelle",
         "//:WORKSPACE",
         "@com_github_bazelbuild_buildtools//buildifier",
         "@go_sdk//:bin/gofmt",
         "@golint//golint",
+        "@io_bazel_rules_go//go/tools/gazelle/gazelle:gazelle",
     ],
     importpath = "github.com/bazelbuild/sandboxfs/admin/lint",
     library = ":go_default_library",

--- a/admin/lint/BUILD.bazel
+++ b/admin/lint/BUILD.bazel
@@ -20,12 +20,12 @@ go_binary(
     name = "lint",
     data = [
         "//:WORKSPACE",
+        "@bazel_gazelle//cmd/gazelle",
         "@com_github_bazelbuild_buildtools//buildifier",
         "@go_sdk//:bin/gofmt",
         "@golint//golint",
-        "@io_bazel_rules_go//go/tools/gazelle/gazelle:gazelle",
     ],
+    embed = [":go_default_library"],
     importpath = "github.com/bazelbuild/sandboxfs/admin/lint",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
 )

--- a/admin/lint/checks.go
+++ b/admin/lint/checks.go
@@ -83,7 +83,7 @@ func checkBuildifier(file string) error {
 // checkGazelle checks if the given file is formatted according to gazelle and, if not, prints
 // a diff detailing what's wrong with the file to stdout and returns an error.
 func checkGazelle(file string) error {
-	return runLinter("../io_bazel_rules_go/go/tools/gazelle/gazelle", "gazelle", "--go_prefix=github.com/bazelbuild/sandboxfs", "--mode=diff", filepath.Dir(file))
+	return runLinter("../bazel_gazelle/cmd/gazelle", "gazelle", "--go_prefix=github.com/bazelbuild/sandboxfs", "--mode=diff", filepath.Dir(file))
 }
 
 // checkGoFmt checks if the given file is formatted according to gofmt and, if not, prints a diff

--- a/admin/lint/lint.go
+++ b/admin/lint/lint.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
 )
 
 // getWorkspaceDir finds the path to the workspace given a path to a WORKSPACE file (which could be
@@ -98,6 +100,11 @@ func main() {
 		log.SetOutput(os.Stderr)
 	} else {
 		log.SetOutput(ioutil.Discard)
+	}
+
+	if err := bazel.EnterRunfiles("sandboxfs", "admin/lint", "lint", "admin/lint"); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(1)
 	}
 
 	workspaceDir, err := getWorkspaceDir(*workspace)

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -24,17 +24,22 @@ readonly rootenv
 do_bazel() {
   bazel run //admin/install -- --prefix="$(pwd)/local"
 
+  # The globs below in the invocation of the binaries exist because of
+  # https://github.com/bazelbuild/rules_go/issues/1239: we cannot predict
+  # the path to the built binaries so we must discover it dynamically.
+  # We know we have built them once, so these should only match one entry.
+
   # TODO(jmmv): We disable Bazel's sandboxing because it denies our tests from
   # using FUSE (e.g. accessing system-wide helper binaries).  Figure out a way
   # to not require this.
   bazel test --spawn_strategy=standalone --test_output=streamed //...
   sudo -H "${rootenv[@]}" -s \
-      ./bazel-bin/integration/go_default_test -test.v -test.timeout=600s \
+      ./bazel-bin/integration/*/go_default_test -test.v -test.timeout=600s \
       -sandboxfs_binary="$(pwd)/local/bin/sandboxfs" \
       -unprivileged_user="${USER}"
 
   # Make sure we can install as root as documented in INSTALL.md.
-  sudo ./bazel-bin/admin/install/install --prefix="$(pwd)/local-root"
+  sudo ./bazel-bin/admin/install/*/install --prefix="$(pwd)/local-root"
 }
 
 do_gotools() {

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -17,7 +17,6 @@ set -e -u -x
 
 rootenv=()
 rootenv+=(PATH="${PATH}")
-rootenv+=(UNPRIVILEGED_USER="${USER}")
 [ "${GOPATH-unset}" = unset ] || rootenv+=(GOPATH="${GOPATH}")
 [ "${GOROOT-unset}" = unset ] || rootenv+=(GOROOT="${GOROOT}")
 readonly rootenv
@@ -29,8 +28,10 @@ do_bazel() {
   # using FUSE (e.g. accessing system-wide helper binaries).  Figure out a way
   # to not require this.
   bazel test --spawn_strategy=standalone --test_output=streamed //...
-  sudo -H "${rootenv[@]}" SANDBOXFS="$(pwd)/local/bin/sandboxfs" -s \
-      ./bazel-bin/integration/go_default_test -test.v -test.timeout=600s
+  sudo -H "${rootenv[@]}" -s \
+      ./bazel-bin/integration/go_default_test -test.v -test.timeout=600s \
+      -sandboxfs_binary="$(pwd)/local/bin/sandboxfs" \
+      -unprivileged_user="${USER}"
 
   # Make sure we can install as root as documented in INSTALL.md.
   sudo ./bazel-bin/admin/install/install --prefix="$(pwd)/local-root"
@@ -41,20 +42,21 @@ do_gotools() {
 
   go test -v -timeout=600s github.com/bazelbuild/sandboxfs/internal/shell
 
-  SANDBOXFS="$(pwd)/sandboxfs" SKIP_NOT_FOR_RELEASE_TEST=yes \
-      go test -v -timeout=600s github.com/bazelbuild/sandboxfs/integration
-  if SANDBOXFS="$(pwd)/sandboxfs" \
-      go test -v -timeout=600s -run TestCli_VersionNotForRelease \
-      github.com/bazelbuild/sandboxfs/integration; then
+  go test -v -timeout=600s github.com/bazelbuild/sandboxfs/integration \
+      -sandboxfs_binary="$(pwd)/sandboxfs" -release_build=false
+  if go test -v -timeout=600s -run TestCli_VersionNotForRelease \
+      github.com/bazelbuild/sandboxfs/integration \
+      -sandboxfs_binary="$(pwd)/sandboxfs"
+  then
     echo "Tests did not catch that the current build is not for release" 1>&2
     exit 1
   else
     echo "Previous test was expected to fail, and it did! All good." 1>&2
   fi
 
-  sudo -H "${rootenv[@]}" \
-      SANDBOXFS="$(pwd)/sandboxfs" SKIP_NOT_FOR_RELEASE_TEST=yes -s \
-      go test -v -timeout=600s github.com/bazelbuild/sandboxfs/integration
+  sudo -H "${rootenv[@]}" -s \
+      go test -v -timeout=600s github.com/bazelbuild/sandboxfs/integration \
+      -sandboxfs_binary="$(pwd)/sandboxfs" -release_build=false
 }
 
 do_lint() {

--- a/admin/travis-install.sh
+++ b/admin/travis-install.sh
@@ -22,8 +22,8 @@ install_bazel() {
     *) osname="${TRAVIS_OS_NAME}" ;;
   esac
 
-  local github="https://github.com/bazelbuild/bazel/releases/download/0.7.0"
-  local url="${github}/bazel-0.7.0-installer-${osname}-x86_64.sh"
+  local github="https://github.com/bazelbuild/bazel/releases/download/0.9.0"
+  local url="${github}/bazel-0.9.0-installer-${osname}-x86_64.sh"
   wget -O install-bazel.sh "${url}"
   chmod +x install-bazel.sh
   ./install-bazel.sh --user

--- a/cmd/sandboxfs/BUILD.bazel
+++ b/cmd/sandboxfs/BUILD.bazel
@@ -20,8 +20,8 @@ go_library(
 
 go_binary(
     name = "sandboxfs",
+    embed = [":go_default_library"],
     importpath = "github.com/bazelbuild/sandboxfs/cmd/sandboxfs",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
     x_defs = {
         "main.packageVersion": PACKAGE_VERSION,

--- a/configure
+++ b/configure
@@ -57,7 +57,11 @@ setup_vscode() {
   # on as targets for the generated gopath.
   bazel build //cmd/sandboxfs:sandboxfs
 
-  ./bazel-bin/external/bazel_gopath/bazel-gopath --workspace="$(pwd)"
+  # The glob below is necessary because of
+  # https://github.com/bazelbuild/rules_go/issues/1239.  Given that we have
+  # done a single build for a single target configuration, we know that the
+  # glob will only match one binary.
+  ./bazel-bin/external/bazel_gopath/*/bazel-gopath --workspace="$(pwd)"
 
   {
     echo '// AUTOMATICALLY GENERATED!!!'

--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -31,8 +31,8 @@ go_test(
     data = [
         "//cmd/sandboxfs",
     ],
+    embed = [":go_default_library"],
     importpath = "github.com/bazelbuild/sandboxfs/integration",
-    library = ":go_default_library",
     deps = [
         "//integration/utils:go_default_library",
         "//internal/sandbox:go_default_library",

--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -16,6 +16,7 @@ go_test(
         "cli_test.go",
         "debug_test.go",
         "layout_test.go",
+        "main_test.go",
         "nesting_test.go",
         "options_test.go",
         "profiling_test.go",
@@ -23,6 +24,9 @@ go_test(
         "read_write_test.go",
         "reconfiguration_test.go",
         "signal_test.go",
+    ],
+    args = [
+        "--sandboxfs_binary=../$(location //cmd/sandboxfs)",
     ],
     data = [
         "//cmd/sandboxfs",

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -16,7 +16,6 @@ package integration
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/bazelbuild/sandboxfs/integration/utils"
@@ -114,8 +113,8 @@ func TestCli_Version(t *testing.T) {
 }
 
 func TestCli_VersionNotForRelease(t *testing.T) {
-	if os.Getenv("SKIP_NOT_FOR_RELEASE_TEST") == "yes" {
-		t.Skipf("Skipped because SKIP_NOT_FOR_RELEASE_TEST is 'yes' in the environment, which means we knowingly built a non-release binary")
+	if !utils.GetConfig().ReleaseBinary {
+		t.Skipf("Binary intentionally built not for release")
 	}
 
 	stdout, _, err := utils.RunAndWait(0, "--version")

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -1,0 +1,42 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package integration
+
+import (
+	"flag"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/sandboxfs/integration/utils"
+)
+
+var (
+	releaseBuild     = flag.Bool("release_build", true, "Whether the tested binary was built for release or not")
+	sandboxfsBinary  = flag.String("sandboxfs_binary", "", "Path to the sandboxfs binary to test; cannot be empty and must point to an existent binary")
+	unprivilegedUser = flag.String("unprivileged_user", "", "Username of the system user to use for tests that require non-root permissions; can be empty, in which case those tests are skipped")
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if len(*sandboxfsBinary) == 0 {
+		log.Fatalf("--sandboxfs_binary must be provided")
+	}
+	if err := utils.SetConfigFromFlags(*releaseBuild, *sandboxfsBinary, *unprivilegedUser); err != nil {
+		log.Fatalf("invalid flags configuration: %v", err)
+	}
+
+	os.Exit(m.Run())
+}

--- a/integration/options_test.go
+++ b/integration/options_test.go
@@ -26,13 +26,9 @@ import (
 func TestOptions_Allow(t *testing.T) {
 	root := utils.RequireRoot(t, "Requires root privileges to spawn sandboxfs under different users")
 
-	username := os.Getenv("UNPRIVILEGED_USER")
-	if username == "" {
-		t.Skipf("UNPRIVILEGED_USER not set; must contain the name of an unprivileged user with FUSE access")
-	}
-	user, err := utils.LookupUser(username)
-	if err != nil {
-		t.Fatalf("Failed to get details about unprivileged user %s: %v", username, err)
+	user := utils.GetConfig().UnprivilegedUser
+	if user == nil {
+		t.Skipf("unprivileged user not set; must contain the name of an unprivileged user with FUSE access")
 	}
 	t.Logf("Using primary unprivileged user: %v", user)
 

--- a/integration/utils/BUILD.bazel
+++ b/integration/utils/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "checks.go",
+        "config.go",
         "doc.go",
         "exec.go",
         "user.go",

--- a/integration/utils/config.go
+++ b/integration/utils/config.go
@@ -1,0 +1,77 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package utils
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// Config represents the configuration for the integration tests as provided in the command line.
+type Config struct {
+	// ReleaseBinary is true if the binary provided in SandboxfsBinary was built in release
+	// mode, false otherwise.
+	ReleaseBinary bool
+
+	// SandboxfsBinary contains the absolute path to the sandboxfs binary to test.
+	SandboxfsBinary string
+
+	// UnprivilegedUser is a non-root user to use when the integration tests are run as root,
+	// by those tests that require dropping privileges.  May be nil, in which case those tests
+	// are skipped.
+	UnprivilegedUser *UnixUser
+}
+
+// globalConfig contains the singleton instance of the configuration.  This must be initialized at
+// test program startup time with the SetConfigFromFlags function and can later be queried at will
+// by any test.
+var globalConfig *Config
+
+// SetConfigFromFlags initializes the test configuration based on the raw values provided by the
+// user on the command line.  Returns an error if any of those values is incorrect.
+func SetConfigFromFlags(releaseBinary bool, rawSandboxfsBinary string, unprivilegedUserName string) error {
+	if globalConfig != nil {
+		panic("SetConfigFromFlags can only be called once")
+	}
+
+	sandboxfsBinary, err := filepath.Abs(rawSandboxfsBinary)
+	if err != nil {
+		return fmt.Errorf("cannot make %s absolute: %v", rawSandboxfsBinary, err)
+	}
+
+	var unprivilegedUser *UnixUser
+	if unprivilegedUserName != "" {
+		unprivilegedUser, err = LookupUser(unprivilegedUserName)
+		if err != nil {
+			return fmt.Errorf("invalid unprivileged user setting %s: %v", unprivilegedUserName, err)
+		}
+	}
+
+	globalConfig = &Config{
+		ReleaseBinary:    releaseBinary,
+		SandboxfsBinary:  sandboxfsBinary,
+		UnprivilegedUser: unprivilegedUser,
+	}
+	return nil
+}
+
+// GetConfig returns the singleon instance of the test configuration.
+func GetConfig() *Config {
+	if globalConfig == nil {
+		panic("GetConfig should have been called from main but was not yet")
+	}
+
+	return globalConfig
+}

--- a/internal/sandbox/BUILD.bazel
+++ b/internal/sandbox/BUILD.bazel
@@ -13,10 +13,10 @@ go_library(
         "sandbox.go",
         "scaffold_dir.go",
     ] + select({
-        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+        "@io_bazel_rules_go//go/platform:darwin": [
             "node_darwin.go",
         ],
-        "@io_bazel_rules_go//go/platform:linux_amd64": [
+        "@io_bazel_rules_go//go/platform:linux": [
             "node_linux.go",
         ],
         "//conditions:default": [],

--- a/internal/shell/BUILD.bazel
+++ b/internal/shell/BUILD.bazel
@@ -10,6 +10,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["shell_test.go"],
+    embed = [":go_default_library"],
     importpath = "github.com/bazelbuild/sandboxfs/internal/shell",
-    library = ":go_default_library",
 )


### PR DESCRIPTION
As part of this change, rerun Gazelle to update all BUILD.bazel files
with new changes.
    
We also have to workaround a change in the paths of the built
Go binaries (https://github.com/bazelbuild/rules_go/issues/1239) in our
instructions and build scripts.