### PR TITLE
Simplify nodes

### DIFF
--- a/internal/sandbox/BUILD.bazel
+++ b/internal/sandbox/BUILD.bazel
@@ -5,12 +5,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
-        "mapped_dir.go",
-        "mapped_file.go",
-        "mapped_symlink.go",
+        "dir.go",
+        "file.go",
         "node.go",
         "root.go",
         "sandbox.go",
+        "symlink.go",
     ] + select({
         "@io_bazel_rules_go//go/platform:darwin": [
             "node_darwin.go",

--- a/internal/sandbox/node.go
+++ b/internal/sandbox/node.go
@@ -175,7 +175,7 @@ func getOrCreateNode(path string, fileInfo os.FileInfo, writable bool) Node {
 	if fileInfo.Mode()&os.ModeType == os.ModeDir {
 		// Directories cannot be cached because they contain entries that are created only
 		// in memory based on the mappings configuration.
-		return newMappedDir(path, fileInfo, writable)
+		return newDir(path, fileInfo, writable)
 	}
 
 	nodeCacheLock.Lock()
@@ -207,9 +207,9 @@ func getOrCreateNode(path string, fileInfo os.FileInfo, writable bool) Node {
 	case os.ModeDir:
 		panic("Directory entries cannot be cached and are handled above")
 	case os.ModeSymlink:
-		node = newMappedSymlink(path, fileInfo, writable)
+		node = newSymlink(path, fileInfo, writable)
 	default:
-		node = newMappedFile(path, fileInfo, writable)
+		node = newFile(path, fileInfo, writable)
 	}
 	nodeCache[path] = node
 	return node

--- a/internal/sandbox/root.go
+++ b/internal/sandbox/root.go
@@ -41,19 +41,19 @@ type Root struct {
 	// dir holds the directory backing the root node. Note that the FUSE API is unaware of this
 	// backing node: any operations that reference the root node must do so through the Root
 	// instance. In that sense, the directory here is just an implementation detail.
-	dir *MappedDir
+	dir *Dir
 
 	// mu protects reads and updates to the dir pointer.
 	mu sync.RWMutex
 }
 
 // NewRoot returns a new instance of Root with the appropriate underlying node.
-func NewRoot(node *MappedDir) *Root {
+func NewRoot(node *Dir) *Root {
 	return &Root{dir: node}
 }
 
 // getDir returns the dir member atomically.
-func (r *Root) getDir() *MappedDir {
+func (r *Root) getDir() *Dir {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.dir
@@ -78,7 +78,7 @@ func (r *Root) getDir() *MappedDir {
 //
 // Well-behaved users should only reconfigure the file system when they know it's quiescent, and
 // this is what we specify in the documentation.
-func (r *Root) Reconfigure(server *fs.Server, newDir *MappedDir) {
+func (r *Root) Reconfigure(server *fs.Server, newDir *Dir) {
 	r.mu.Lock()
 	oldDir := r.dir
 	r.dir = newDir
@@ -141,11 +141,8 @@ func (r *Root) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenR
 //
 // TODO(jmmv): This is not semantically correct: we shouldn't be "opening" the backing directory as
 // we do below, because a readdir operation from the kernel on an already-open root directory causes
-// a spurious open of an unrelated entity.  This shouldn't be a problem (and we do that for mapped
-// nodes anyway), but we should find a solution for this.  I'm afraid the answer is to combine
-// MappedDir and ScaffoldDir under the same type and to get rid of the Root type.  This would have
-// the benefit of allowing us to maintain the identity of directory nodes across reconfigurations
-// more easily, which can be interesting on its own.
+// a spurious open of an unrelated entity.  We may be able to remove this once we fold
+// reconfigurations into directories and thus preserve the identity of the root directory.
 func (r *Root) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -66,7 +66,7 @@ type FS struct {
 }
 
 // Reconfigure resets the tree under this node to the new configuration.
-func (f *FS) Reconfigure(server *fs.Server, root *MappedDir) {
+func (f *FS) Reconfigure(server *fs.Server, root *Dir) {
 	// TODO(pallavag): Right now, we do not reuse inode numbers, because it is
 	// uncertain if doing so would be valid from a correctness perspective.
 	// Once the code has been well tested, it may be worthwile to try resetting
@@ -100,7 +100,7 @@ func readConfig(reader *bufio.Reader) ([]byte, error) {
 // initFromReader initializes a filesystem configuration after reading the config from the passed
 // reader.  Reaching EOF on the reader causes this function to return io.EOF, which the caller
 // must handle gracefully.
-func initFromReader(reader *bufio.Reader) (*MappedDir, error) {
+func initFromReader(reader *bufio.Reader) (*Dir, error) {
 	configRead, err := readConfig(reader)
 	if err != nil {
 		if err == io.EOF {
@@ -139,7 +139,7 @@ func reconfigurationListener(server *fs.Server, filesystem *FS, input io.Reader,
 }
 
 // Serve sets up the work environment before starting to serve the filesystem.
-func Serve(c *fuse.Conn, dir *MappedDir, dynamic *DynamicConf) error {
+func Serve(c *fuse.Conn, dir *Dir, dynamic *DynamicConf) error {
 	f := &FS{NewRoot(dir)}
 	server := fs.New(c, nil)
 	if dynamic != nil {
@@ -176,8 +176,8 @@ func tokenizePath(path string) []string {
 }
 
 // CreateRoot generates a directory tree to represent the given mappings.
-func CreateRoot(mappings []MappingSpec) (*MappedDir, error) {
-	var root *MappedDir
+func CreateRoot(mappings []MappingSpec) (*Dir, error) {
+	var root *Dir
 	for _, mapping := range mappings {
 		components := tokenizePath(mapping.Mapping)
 		if len(components) == 0 {
@@ -197,11 +197,11 @@ func CreateRoot(mappings []MappingSpec) (*MappedDir, error) {
 			if fileInfo.Mode()&os.ModeType != os.ModeDir {
 				return nil, fmt.Errorf("cannot map file %s at root: must be a directory", mapping.Target)
 			}
-			root = newMappedDir(mapping.Target, fileInfo, mapping.Writable)
+			root = newDir(mapping.Target, fileInfo, mapping.Writable)
 			root.isMapping = true
 		} else {
 			if root == nil {
-				root = newMappedDirEmpty()
+				root = newDirEmpty()
 			}
 			dirNode := root.LookupOrCreateDirs(components[1 : len(components)-1])
 			newNode := getOrCreateNode(mapping.Target, fileInfo, mapping.Writable)
@@ -212,7 +212,7 @@ func CreateRoot(mappings []MappingSpec) (*MappedDir, error) {
 		}
 	}
 	if root == nil {
-		root = newMappedDirEmpty()
+		root = newDirEmpty()
 	}
 	return root, nil
 }

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -44,8 +44,8 @@ func areTreesSimilar(path string, got Node, want Node) error {
 		return fmt.Errorf("in %s: got isMapping=%v underlyingPath=%v, want isMapping=%v, underlyingPath=%v", path, gotIsMapping, gotUnderlyingPath, wantIsMapping, wantUnderlyingPath)
 	}
 
-	if gotDir, ok := got.(*MappedDir); ok {
-		wantDir := want.(*MappedDir)
+	if gotDir, ok := got.(*Dir); ok {
+		wantDir := want.(*Dir)
 
 		for gotName, gotNode := range gotDir.children {
 			if wantNode, ok := wantDir.children[gotName]; ok {
@@ -83,14 +83,14 @@ func TestCreateRoot_Ok(t *testing.T) {
 	testData := []struct {
 		name     string
 		mappings []MappingSpec
-		wantDir  *MappedDir
+		wantDir  *Dir
 	}{
 		{
 			"JustRoot",
 			[]MappingSpec{
 				{Mapping: "/", Target: tempDir},
 			},
-			&MappedDir{
+			&Dir{
 				BaseNode: BaseNode{optionalUnderlyingPath: tempDir},
 			},
 		},
@@ -100,10 +100,10 @@ func TestCreateRoot_Ok(t *testing.T) {
 				{Mapping: "/", Target: tempDir},
 				{Mapping: "/foo", Target: nestedTempFile},
 			},
-			&MappedDir{
+			&Dir{
 				BaseNode: BaseNode{optionalUnderlyingPath: tempDir},
 				children: map[string]Node{
-					"foo": &MappedFile{
+					"foo": &File{
 						BaseNode: BaseNode{optionalUnderlyingPath: nestedTempFile},
 					},
 				},
@@ -114,13 +114,13 @@ func TestCreateRoot_Ok(t *testing.T) {
 			[]MappingSpec{
 				{Mapping: "/foo/bar/baz", Target: nestedTempFile},
 			},
-			&MappedDir{
+			&Dir{
 				children: map[string]Node{
-					"foo": &MappedDir{
+					"foo": &Dir{
 						children: map[string]Node{
-							"bar": &MappedDir{
+							"bar": &Dir{
 								children: map[string]Node{
-									"baz": &MappedFile{
+									"baz": &File{
 										BaseNode: BaseNode{optionalUnderlyingPath: nestedTempFile},
 									},
 								},
@@ -139,12 +139,12 @@ func TestCreateRoot_Ok(t *testing.T) {
 				{Mapping: "/foo", Target: tempDir},
 				{Mapping: "/foo/dir", Target: tempDir},
 			},
-			&MappedDir{
+			&Dir{
 				children: map[string]Node{
-					"foo": &MappedDir{
+					"foo": &Dir{
 						BaseNode: BaseNode{optionalUnderlyingPath: tempDir},
 						children: map[string]Node{
-							"dir": &MappedDir{
+							"dir": &Dir{
 								BaseNode: BaseNode{optionalUnderlyingPath: tempDir},
 							},
 						},
@@ -160,24 +160,24 @@ func TestCreateRoot_Ok(t *testing.T) {
 				{Mapping: "/foo/bar/baz/symlink", Target: nestedTempSymlink},
 				{Mapping: "/foo/bar/file", Target: nestedTempFile},
 			},
-			&MappedDir{
+			&Dir{
 				children: map[string]Node{
-					"foo": &MappedDir{
+					"foo": &Dir{
 						children: map[string]Node{
-							"bar": &MappedDir{
+							"bar": &Dir{
 								BaseNode: BaseNode{optionalUnderlyingPath: tempDir},
 								children: map[string]Node{
-									"baz": &MappedDir{
+									"baz": &Dir{
 										children: map[string]Node{
-											"dup": &MappedDir{
+											"dup": &Dir{
 												BaseNode: BaseNode{optionalUnderlyingPath: nestedTempDir},
 											},
-											"symlink": &MappedSymlink{
+											"symlink": &Symlink{
 												BaseNode: BaseNode{optionalUnderlyingPath: nestedTempSymlink},
 											},
 										},
 									},
-									"file": &MappedFile{
+									"file": &File{
 										BaseNode: BaseNode{optionalUnderlyingPath: nestedTempFile},
 									},
 								},

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -194,7 +194,7 @@ func TestCreateRoot_Ok(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create hierarchy: %v", err)
 			}
-			if err := areTreesSimilar("/", root.(*MappedDir), d.wantDir); err != nil {
+			if err := areTreesSimilar("/", root, d.wantDir); err != nil {
 				t.Error(err)
 			}
 		})

--- a/internal/sandbox/symlink.go
+++ b/internal/sandbox/symlink.go
@@ -22,24 +22,24 @@ import (
 	"golang.org/x/net/context"
 )
 
-// MappedSymlink is a node that represents a symlink backed by another symlink that lives outside of
+// Symlink is a node that represents a symlink backed by another symlink that lives outside of
 // the mount point.
-type MappedSymlink struct {
+type Symlink struct {
 	BaseNode
 }
 
-// newMappedSymlink creates a new symlink node to represent the given underlying path.
+// newSymlink creates a new symlink node to represent the given underlying path.
 //
 // This function should never be called to explicitly create nodes. Instead, use the getOrCreateNode
 // function, which respects the global node cache.
-func newMappedSymlink(path string, fileInfo os.FileInfo, writable bool) *MappedSymlink {
-	return &MappedSymlink{
+func newSymlink(path string, fileInfo os.FileInfo, writable bool) *Symlink {
+	return &Symlink{
 		BaseNode: newBaseNode(path, fileInfo, writable),
 	}
 }
 
 // Readlink reads a symlink and returns the string path to its destination.
-func (s *MappedSymlink) Readlink(_ context.Context, req *fuse.ReadlinkRequest) (string, error) {
+func (s *Symlink) Readlink(_ context.Context, req *fuse.ReadlinkRequest) (string, error) {
 	underlyingPath, isMapped := s.UnderlyingPath()
 	if !isMapped {
 		panic("Want to read a symlink but we don't have an underlying path")
@@ -50,7 +50,7 @@ func (s *MappedSymlink) Readlink(_ context.Context, req *fuse.ReadlinkRequest) (
 }
 
 // Dirent returns the directory entry corresponding to the symlink.
-func (s *MappedSymlink) Dirent(name string) fuse.Dirent {
+func (s *Symlink) Dirent(name string) fuse.Dirent {
 	return fuse.Dirent{
 		Inode: s.Inode(),
 		Name:  name,
@@ -59,8 +59,8 @@ func (s *MappedSymlink) Dirent(name string) fuse.Dirent {
 }
 
 // invalidate clears the kernel cache corresponding to this symlink.
-func (s *MappedSymlink) invalidate(server *fs.Server) {
-	// We assume that, as long as a MappedSymlink object is alive, the node corresponds to a
+func (s *Symlink) invalidate(server *fs.Server) {
+	// We assume that, as long as a Symlink object is alive, the node corresponds to a
 	// non-deleted underlying symlink. Therefore, do not invalidate the node itself. This is
 	// important to keep entries alive across reconfigurations, which helps performance.
 }


### PR DESCRIPTION
Mechanical deletion of the `Dir` interface and renames of all node types. Two separate commits... but hopefully not a problem this time due to their simplicity.