### PR TITLE
Drop the subcommand-based interface

### DIFF
--- a/cmd/sandboxfs/sandboxfs.1
+++ b/cmd/sandboxfs/sandboxfs.1
@@ -11,7 +11,7 @@
 .\" WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 .\" License for the specific language governing permissions and limitations
 .\" under the License.
-.Dd January 21, 2018
+.Dd February 27, 2018
 .Dt SANDBOXFS 1
 .Os
 .Sh NAME
@@ -22,23 +22,14 @@
 .Op Fl -allow Ar who
 .Op Fl -cpu_profile Ar file
 .Op Fl -debug
+.Op Fl -input Ar file
 .Op Fl -listen_address Ar host:port
 .Op Fl -help
+.Op Fl -mapping Ar type:mapping:target
 .Op Fl -mem_profile Ar file
+.Op Fl -output Ar file
 .Op Fl -version
 .Op Fl -volume_name Ar volume_name
-dynamic
-.Op Fl -help
-.Op Fl -input file
-.Op Fl -output file
-.Ar mount_point
-.Nm
-.Op Fl -debug
-.Op Fl -help
-.Op Fl -volume_name Ar volume_name
-static
-.Op Fl -help
-.Op Fl -mapping Ar type:mapping:target
 .Ar mount_point
 .Sh DESCRIPTION
 .Nm
@@ -53,7 +44,20 @@ is designed to allow running commands with limited access to the file system by
 using the virtual tree as their new root, and to do so consistently across a
 variety of platforms.
 .Pp
-The following general flags are recognized for all commands:
+The sandbox instance mounted at
+.Ar mount_point
+is initially configured with the mapping specifications provided via repeated
+instances of
+.Fl -mapping .
+Once running, the mount point can be reconfigured any number of times:
+.Nm
+listens for reconfiguration requests on the file specified by
+.Fl -input
+and reconfigures the mappings as requested, emiting a response on the file
+specified by
+.Fl -output .
+.Pp
+The following flags are recognized:
 .Bl -tag -width XXXX
 .It Fl -allow Ar who
 Specifies who should have access to the file system.
@@ -99,6 +103,13 @@ because only one profiling mechanism can be enabled at once.
 .It Fl -debug
 Logs details about all FUSE operations received and responded to by the FUSE
 process to stderr.
+.It Fl -input Ar path
+Points to the file from which to read new configuration requests, or
+.Sq -
+(the default) for stdin.
+See the
+.Sx Reconfigurations
+subsection for details on the contents and behavior of the input file.
 .It Fl -listen_address Ar host:port
 Starts an HTTP server listening on
 .Ar host:port .
@@ -114,6 +125,14 @@ because only one profiling mechanism can be enabled at once.
 .It Fl -help
 Prints global help details and exits.
 Specifying this flag causes all other valid flags and arguments to be ignored.
+.It Fl -mapping Ar type:mapping:target
+Registers a new mapping.
+This flag can be given an arbitrary number of times as long as the same
+.Ar mapping
+is not repeated.
+See the
+.Sx Mapping specifications
+subsection for details on how a mapping is specified.
 .It Fl -mem_profile Ar file
 Enables memory profiling and writes a profile to the given
 .Ar file
@@ -122,6 +141,13 @@ on exit.
 This option is incompatible with
 .Fl -listen_address
 because only one profiling mechanism can be enabled at once.
+.It Fl -output Ar path
+Points to the file to which to write confirmations of reconfiguration, or
+.Sq -
+(the default) for stdout.
+See the
+.Sx Reconfigurations
+subsection for details on the contents and behavior of the output file.
 .It Fl -version
 Prints version information and exits.
 Specifying this flag causes all other valid flags and arguments to be ignored
@@ -197,19 +223,15 @@ can be modified at will through the mount point.
 Writes through the moint point are applied immediately to the underlying target
 directory.
 .El
-.Ss The dynamic command
-The
-.Sq dynamic
-command mounts a
+.Ss Reconfigurations
+While a mount point is live,
 .Nm
-instance on the given
-.Ar mount_point
-with a view configured at run-time after the mount point is live.
-.Nm
-will listen for new configuration requests on a specific input file and will
-write a confirmation of reconfiguration to another specific output file.
+listens for reconfiguration requests on the file specified by
+.Fl -input
+and writes confirmations to the file specified by
+.Fl -output .
 .Pp
-A dynamic mount point can be configured any number of times while it is running,
+The mount point can be configured any number of times while mounted,
 which allows for processes to efficiently change the view of the sandbox at will
 without having to remount it.
 Closing the input file causes
@@ -230,26 +252,6 @@ will not deadlock nor crash).
 As a result, it is highly recommended that you only send reconfiguration
 requests when you know that the file system is quiescent.
 .Pp
-The following flags are recognized by this command:
-.Bl -tag -width XXXX
-.It Fl -help
-Prints information specific to this command and exits.
-.It Fl -input Ar path
-Points to the file from which to read new configuration requests, or
-.Sq -
-for stdin.
-.Pp
-Default:
-.Sq -
-.It Fl -output Ar path
-Points to the file to which to write confirmations of reconfiguration,
-.Sq -
-for stdout.
-.Pp
-Default:
-.Sq -
-.El
-.Pp
 Configuration requests are formatted as a JSON map followed by a single blank
 line.
 Each entry in the ordered map specifies a single mapping specification, with the
@@ -267,28 +269,6 @@ accepts a valid reconfiguration request and the file system is fully
 reconfigured, the single line
 .Sq Done
 is written to the output file.
-.Ss The static command
-The
-.Sq static
-command mounts a
-.Nm
-instance on the given
-.Ar mount_point
-with a view configured at startup time via command-line flags.
-.Pp
-The following flags are recognized by this command:
-.Bl -tag -width XXXX
-.It Fl -help
-Prints information specific to this command and exits.
-.It Fl -mapping Ar type:mapping:target
-Registers a new mapping.
-This flag can be given an arbitrary number of times as long as the same
-.Ar mapping
-is not repeated.
-See the
-.Sx Mapping specifications
-subsection for details on how a mapping is specified.
-.El
 .Sh EXIT STATUS
 .Nm
 exits with 0 if the file system was both mounted and unmounted cleanly; 1 on a
@@ -309,24 +289,20 @@ is implemented), the reception of a signal will cause
 .Nm
 to return 1 instead of terminating with a signal condition.
 .Sh EXAMPLES
-The following example configures a static sandbox that maps the whole host's
+The following example configures a sandbox that maps the whole host's
 file system but clears
 .Pa /tmp
 to point into a sandbox-specific writable directory:
 .Bd -literal -indent
-sandboxfs \\
-    static \\
-    --mapping=ro:/:/ \\
-    --mapping=rw:/tmp:/tmp/fresh-tmp \\
-    /mnt
+sandboxfs --mapping=ro:/:/ --mapping=rw:/tmp:/tmp/fresh-tmp /mnt
 .Ed
 .Pp
-This same configuration can be expressed as the following JSON data when using
-the dynamic mode:
+This same configuration can be expressed as the following JSON data and can be
+fed via the input file:
 .Bd -literal -indent
 [
-    {"Mapping": "/tmp", "Target": "/tmp/fresh-tmp", "Writable": false},
-    {"Mapping": "/", "Target": "/", "Writable": true}
+    {"Mapping": "/", "Target": "/", "Writable": true},
+    {"Mapping": "/tmp", "Target": "/tmp/fresh-tmp", "Writable": false}
 ]
 .Ed
 .Sh AUTHORS
@@ -388,4 +364,11 @@ instance in order to offer good performance across reconfigurations.
 However, this cache does not currently implement any expiration policy, which
 means that memory usage can grow unboundedly if many different files are
 mapped and accessed through the sandbox.
+.It
+If a FIFO is used for
+.Fl input ,
+.Nm
+will block until a separate process opens the FIFO for writing.
+This happens even before the file system starts serving, which means the file
+system is not usable until the FIFO is opened.
 .El

--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -24,7 +24,7 @@ import (
 func TestDebug_FuseOpsInLog(t *testing.T) {
 	stderr := new(bytes.Buffer)
 
-	state := utils.MountSetupWithOutputs(t, nil, stderr, "--debug", "static", "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetupWithOutputs(t, nil, stderr, "--debug", "-mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("cookie"), 0644, "")

--- a/integration/layout_test.go
+++ b/integration/layout_test.go
@@ -33,7 +33,7 @@ func TestLayout_MountPointDoesNotExist(t *testing.T) {
 	mountPoint := filepath.Join(tempDir, "non-existent")
 	wantStderr := "unable to mount: " + mountPoint + " does not exist\n"
 
-	stdout, stderr, err := utils.RunAndWait(1, "static", "--mapping=ro:/:"+tempDir, mountPoint)
+	stdout, stderr, err := utils.RunAndWait(1, "--mapping=ro:/:"+tempDir, mountPoint)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestLayout_RootMustBeDirectory(t *testing.T) {
 
 	wantStderr := "unable to init sandbox: cannot map file " + file + " at root: must be a directory\n"
 
-	stdout, stderr, err := utils.RunAndWait(1, "static", "--mapping=ro:/:"+file, "irrelevant-mount-point")
+	stdout, stderr, err := utils.RunAndWait(1, "--mapping=ro:/:"+file, "irrelevant-mount-point")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestLayout_RootMustBeDirectory(t *testing.T) {
 func TestLayout_TargetDoesNotExist(t *testing.T) {
 	wantStderr := "failed to stat /non-existent when mapping /.*\n"
 
-	stdout, stderr, err := utils.RunAndWait(1, "static", "--mapping=ro:/:/non-existent", "irrelevant-mount-point")
+	stdout, stderr, err := utils.RunAndWait(1, "--mapping=ro:/:/non-existent", "irrelevant-mount-point")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func TestLayout_DuplicateMapping(t *testing.T) {
 	path2 := filepath.Join(tempDir, "2")
 	utils.MustWriteFile(t, path2, 0644, "")
 
-	stdout, stderr, err := utils.RunAndWait(1, "static", "--mapping=ro:/:"+tempDir, "--mapping=ro:/a/a:"+path1, "--mapping=ro:/a/b:"+tempDir, "--mapping=ro:/a/a:"+path2, "irrelevant-mount-point")
+	stdout, stderr, err := utils.RunAndWait(1, "--mapping=ro:/:"+tempDir, "--mapping=ro:/a/a:"+path1, "--mapping=ro:/a/b:"+tempDir, "--mapping=ro:/a/a:"+path2, "irrelevant-mount-point")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestLayout_TargetIsScaffoldDirectory(t *testing.T) {
 
 	wantStderr := "unable to init sandbox: cannot map /a: already mapped\n"
 
-	stdout, stderr, err := utils.RunAndWait(1, "static", "--mapping=ro:/a/b/c:"+tempDir, "--mapping=ro:/a:"+file, "irrelevant-mount-point")
+	stdout, stderr, err := utils.RunAndWait(1, "--mapping=ro:/a/b/c:"+tempDir, "--mapping=ro:/a:"+file, "irrelevant-mount-point")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/nesting_test.go
+++ b/integration/nesting_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestNesting_ScaffoldIntermediateComponents(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=ro:/:%ROOT%", "-mapping=ro:/1/2/3/4/5:%ROOT%/subdir")
+	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%", "-mapping=ro:/1/2/3/4/5:%ROOT%/subdir")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("subdir", "file"), 0644, "some contents")
@@ -59,7 +59,7 @@ func TestNesting_ScaffoldIntermediateComponentsAreImmutable(t *testing.T) {
 	// attempt real writes.
 	root := utils.RequireRoot(t, "Requires root privileges to write to directories with mode 0555")
 
-	state := utils.MountSetupWithUser(t, root, "static", "-mapping=ro:/:%ROOT%", "-mapping=rw:/1/2/3:%ROOT%/subdir")
+	state := utils.MountSetupWithUser(t, root, "-mapping=ro:/:%ROOT%", "-mapping=rw:/1/2/3:%ROOT%/subdir")
 	defer state.TearDown(t)
 
 	for _, dir := range []string{"1/foo", "1/2/foo"} {
@@ -75,7 +75,7 @@ func TestNesting_ScaffoldIntermediateComponentsAreImmutable(t *testing.T) {
 }
 
 func TestNesting_ReadWriteWithinReadOnly(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%", "-mapping=ro:/ro:%ROOT%/one/two", "-mapping=rw:/ro/rw:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%", "-mapping=ro:/ro:%ROOT%/one/two", "-mapping=rw:/ro/rw:%ROOT%")
 	defer state.TearDown(t)
 
 	if err := os.MkdirAll(state.MountPath("ro/hello"), 0755); err == nil {
@@ -87,7 +87,7 @@ func TestNesting_ReadWriteWithinReadOnly(t *testing.T) {
 }
 
 func TestNesting_SameTarget(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=ro:/:%ROOT%", "-mapping=rw:/dir1:%ROOT%/same", "-mapping=rw:/dir2/dir3/dir4:%ROOT%/same")
+	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%", "-mapping=rw:/dir1:%ROOT%/same", "-mapping=rw:/dir2/dir3/dir4:%ROOT%/same")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.MountPath("dir1/file"), 0644, "old contents")
@@ -117,7 +117,7 @@ func TestNesting_SameTarget(t *testing.T) {
 }
 
 func TestNesting_PreserveSymlinks(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=ro:/:%ROOT%", "-mapping=ro:/dir1/dir2:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%", "-mapping=ro:/dir1/dir2:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("file"), 0644, "file in root directory")

--- a/integration/options_test.go
+++ b/integration/options_test.go
@@ -70,7 +70,7 @@ func TestOptions_Allow(t *testing.T) {
 				}
 				defer os.RemoveAll(tempDir)
 
-				_, stderr, err := utils.RunAndWait(1, d.allowFlag, "static", "-mapping=ro:/:/", tempDir)
+				_, stderr, err := utils.RunAndWait(1, d.allowFlag, "-mapping=ro:/:/", tempDir)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -84,7 +84,7 @@ func TestOptions_Allow(t *testing.T) {
 			if d.allowFlag != "" {
 				args = append(args, d.allowFlag)
 			}
-			args = append(args, "static", "-mapping=ro:/:%ROOT%")
+			args = append(args, "-mapping=ro:/:%ROOT%")
 
 			state := utils.MountSetupWithUser(t, user, args...)
 			defer state.TearDown(t)

--- a/integration/profiling_test.go
+++ b/integration/profiling_test.go
@@ -34,7 +34,7 @@ var listenAddressRegex = regexp.MustCompile(`starting HTTP server on ([^:]+:\d+)
 
 func TestProfiling_Http(t *testing.T) {
 	stderr := new(bytes.Buffer)
-	state := utils.MountSetupWithOutputs(t, nil, stderr, "--listen_address=localhost:0", "static", "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetupWithOutputs(t, nil, stderr, "--listen_address=localhost:0", "-mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	matches := listenAddressRegex.FindStringSubmatch(stderr.String())
@@ -83,7 +83,7 @@ func TestProfiling_FileProfiles(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.name, func(t *testing.T) {
-			state := utils.MountSetup(t, append(d.args, "static", "-mapping=ro:/:%ROOT%")...)
+			state := utils.MountSetup(t, append(d.args, "-mapping=ro:/:%ROOT%")...)
 			// Explicitly stop sandboxfs (which is different to what most other tests do).  We need
 			// to do this here to cause the profiles to be written to disk.
 			state.TearDown(t)
@@ -127,7 +127,7 @@ func TestProfiling_BadConfiguration(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.name, func(t *testing.T) {
-			stdout, stderr, err := utils.RunAndWait(d.wantExitCode, append(d.args, "static", "/non-existent")...)
+			stdout, stderr, err := utils.RunAndWait(d.wantExitCode, append(d.args, "/non-existent")...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/integration/read_only_test.go
+++ b/integration/read_only_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestReadOnly_DirectoryStructure(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=ro:/:%ROOT%", "-mapping=ro:/mappings/dir:%ROOT%/mappings/dir", "-mapping=ro:/mappings/scaffold/dir:%ROOT%/mappings/dir")
+	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%", "-mapping=ro:/mappings/dir:%ROOT%/mappings/dir", "-mapping=ro:/mappings/scaffold/dir:%ROOT%/mappings/dir")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("dir1"), 0755)
@@ -52,7 +52,7 @@ func TestReadOnly_DirectoryStructure(t *testing.T) {
 }
 
 func TestReadOnly_FileContents(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("file"), 0400, "foo")
@@ -72,7 +72,7 @@ func TestReadOnly_FileContents(t *testing.T) {
 }
 
 func TestReadOnly_ReplaceUnderlyingFile(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	externalFile := state.RootPath("foo")
@@ -104,7 +104,7 @@ func TestReadOnly_ReplaceUnderlyingFile(t *testing.T) {
 }
 
 func TestReadOnly_MoveUnderlyingDirectory(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("first/a"), 0755)
@@ -137,7 +137,7 @@ func TestReadOnly_MoveUnderlyingDirectory(t *testing.T) {
 func TestReadOnly_TargetDoesNotExist(t *testing.T) {
 	wantStderr := `failed to stat /non-existent when mapping /:`
 
-	stdout, stderr, err := utils.RunAndWait(1, "static", "--mapping=ro:/:/non-existent", "irrelevant-mount-point")
+	stdout, stderr, err := utils.RunAndWait(1, "--mapping=ro:/:/non-existent", "irrelevant-mount-point")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestReadOnly_TargetDoesNotExist(t *testing.T) {
 }
 
 func TestReadOnly_RepeatedReadDirsWhileDirIsOpen(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=ro:/:%ROOT%", "-mapping=ro:/dir:%ROOT%/dir", "-mapping=ro:/scaffold/abc:%ROOT%/dir")
+	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%", "-mapping=ro:/dir:%ROOT%/dir", "-mapping=ro:/scaffold/abc:%ROOT%/dir")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("mapped-dir"), 0755)
@@ -193,7 +193,7 @@ func TestReadOnly_RepeatedReadDirsWhileDirIsOpen(t *testing.T) {
 }
 
 func TestReadOnly_Attributes(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("dir"), 0755)
@@ -283,7 +283,7 @@ func TestReadOnly_Access(t *testing.T) {
 	//
 	// Note also that we must mount with "allow=other" so that our unprivileged executions
 	// can access the file system.
-	state := utils.MountSetupWithUser(t, root, "-allow=other", "static", "-mapping=ro:/:%ROOT%", "-mapping=ro:/scaffold/dir/foo:%ROOT%/foo")
+	state := utils.MountSetupWithUser(t, root, "-allow=other", "-mapping=ro:/:%ROOT%", "-mapping=ro:/scaffold/dir/foo:%ROOT%/foo")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("all"), 0777) // Place where "user" can create entries.
@@ -356,7 +356,7 @@ func TestReadOnly_Access(t *testing.T) {
 }
 
 func TestReadOnly_HardLinkCountsAreFixed(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=ro:/:%ROOT%", "-mapping=ro:/scaffold/dir:%ROOT%/dir")
+	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%", "-mapping=ro:/scaffold/dir:%ROOT%/dir")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("dir"), 0755)

--- a/integration/read_write_test.go
+++ b/integration/read_write_test.go
@@ -48,7 +48,7 @@ func openAndDelete(path string, mode int) (int, error) {
 }
 
 func TestReadWrite_CreateFile(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("file"), 0644, "original content")
@@ -64,7 +64,7 @@ func TestReadWrite_CreateFile(t *testing.T) {
 }
 
 func TestReadWrite_Remove(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%", "-mapping=rw:/mapped-dir:%ROOT%/mapped-dir", "-mapping=rw:/scaffold/dir:%ROOT%/scaffold-dir")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%", "-mapping=rw:/mapped-dir:%ROOT%/mapped-dir", "-mapping=rw:/scaffold/dir:%ROOT%/scaffold-dir")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("dir"), 0755)
@@ -119,7 +119,7 @@ func TestReadWrite_Remove(t *testing.T) {
 }
 
 func TestReadWrite_RewriteFile(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("file"), 0644, "original content")
@@ -134,7 +134,7 @@ func TestReadWrite_RewriteFile(t *testing.T) {
 }
 
 func TestReadWrite_RewriteFileWithShorterContent(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.MountPath("file"), 0644, "very long contents")
@@ -145,7 +145,7 @@ func TestReadWrite_RewriteFileWithShorterContent(t *testing.T) {
 }
 
 func TestReadWrite_InodeReassignedAfterRecreation(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	path := state.MountPath("file")
@@ -181,7 +181,7 @@ func TestReadWrite_InodeReassignedAfterRecreation(t *testing.T) {
 }
 
 func TestReadWrite_FstatOnDeletedNode(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.MountPath("dir"), 0755)
@@ -227,7 +227,7 @@ func TestReadWrite_FstatOnDeletedNode(t *testing.T) {
 }
 
 func TestReadWrite_Truncate(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.MountPath("file"), 0644, "very long contents")
@@ -243,7 +243,7 @@ func TestReadWrite_Truncate(t *testing.T) {
 }
 
 func TestReadWrite_FtruncateOnDeletedFile(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	originalContent := "very long contents"
@@ -338,7 +338,7 @@ func doRenameTest(t *testing.T, oldOuterPath, newOuterPath, oldInnerPath, newInn
 }
 
 func TestReadWrite_RenameFile(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	oldOuterPath := state.RootPath("old-name")
@@ -349,7 +349,7 @@ func TestReadWrite_RenameFile(t *testing.T) {
 }
 
 func TestReadWrite_MoveFile(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	oldOuterPath := state.RootPath("dir1/dir2/old-name")
@@ -362,7 +362,7 @@ func TestReadWrite_MoveFile(t *testing.T) {
 func TestReadWrite_Mknod(t *testing.T) {
 	utils.RequireRoot(t, "Requires root privileges to create arbitrary nodes")
 
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	// checkNode ensures that a given file is of the specified type and, if the type indicates
@@ -464,7 +464,7 @@ func TestReadWrite_Mknod(t *testing.T) {
 }
 
 func TestReadWrite_Chmod(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	// checkPerm ensures that the given file has the given permissions on the underlying file
@@ -540,7 +540,7 @@ func TestReadWrite_Chmod(t *testing.T) {
 }
 
 func TestReadWrite_FchmodOnDeletedNode(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.MountPath("dir"), 0755)
@@ -581,7 +581,7 @@ func TestReadWrite_FchmodOnDeletedNode(t *testing.T) {
 func TestReadWrite_Chown(t *testing.T) {
 	utils.RequireRoot(t, "Requires root privileges to change test file ownership")
 
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	// checkOwners ensures that the given file is owned by the given user and group on the
@@ -648,7 +648,7 @@ func TestReadWrite_Chown(t *testing.T) {
 func TestReadWrite_FchownOnDeletedNode(t *testing.T) {
 	utils.RequireRoot(t, "Requires root privileges to change test file ownership")
 
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.MountPath("dir"), 0755)
@@ -687,7 +687,7 @@ func TestReadWrite_FchownOnDeletedNode(t *testing.T) {
 }
 
 func TestReadWrite_Chtimes(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	// checkTimes ensures that the given file has the desired timing information on the
@@ -797,7 +797,7 @@ func TestReadWrite_Chtimes(t *testing.T) {
 }
 
 func TestReadWrite_FutimesOnDeletedNode(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.MountPath("dir"), 0755)
@@ -843,7 +843,7 @@ func TestReadWrite_FutimesOnDeletedNode(t *testing.T) {
 }
 
 func TestReadWrite_HardLinksNotSupported(t *testing.T) {
-	state := utils.MountSetup(t, "static", "-mapping=rw:/:%ROOT%", "-mapping=rw:/dir:%ROOT%/dir", "-mapping=rw:/scaffold/name3:%ROOT%/dir2")
+	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%", "-mapping=rw:/dir:%ROOT%/dir", "-mapping=rw:/scaffold/name3:%ROOT%/dir2")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("name1"), 0644, "")

--- a/integration/signal_test.go
+++ b/integration/signal_test.go
@@ -54,7 +54,7 @@ func TestSignal_RaceBetweenSignalSetupAndMount(t *testing.T) {
 	ok := true
 	for delayMs := 2; ok && delayMs < 200; delayMs += 2 {
 		ok = t.Run(fmt.Sprintf("Delay%v", delayMs), func(t *testing.T) {
-			state := utils.MountSetup(t, "dynamic")
+			state := utils.MountSetup(t)
 			defer state.TearDown(t)
 
 			time.Sleep(time.Duration(delayMs) * time.Millisecond)
@@ -74,7 +74,7 @@ func TestSignal_UnmountWhenCaught(t *testing.T) {
 		t.Run(signal.String(), func(t *testing.T) {
 			stderr := new(bytes.Buffer)
 
-			state := utils.MountSetupWithOutputs(t, nil, stderr, "static", "-mapping=ro:/:%ROOT%")
+			state := utils.MountSetupWithOutputs(t, nil, stderr, "-mapping=ro:/:%ROOT%")
 			defer state.TearDown(t)
 
 			utils.MustWriteFile(t, state.RootPath("a"), 0644, "")
@@ -105,7 +105,7 @@ func TestSignal_QueuedWhileInUse(t *testing.T) {
 	defer stderrWriter.Close()
 	stderr := bufio.NewScanner(stderrReader)
 
-	state := utils.MountSetupWithOutputs(t, nil, stderrWriter, "static", "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetupWithOutputs(t, nil, stderrWriter, "-mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	// Create a file under the root directory and open it via the mount point to keep the file


### PR DESCRIPTION
Merge the static and dynamic commands into one, which allows us to drop the
subcommand-based interface.  There never was a good reason to split the
behavior: we can just say that a sandboxfs instance starts running with the
mappings provided on the command line and that it can later be reconfigured
at will via the input/output files.

I'm intentionally not changing the flag names nor the general behavior of
reconfigurations to keep this change simple: fixing callers of sandboxfs
(e.g. all the integration tests) is as simple as dropping the "static"
and "dynamic" subcommand names from the calls.  Moving onto a different
interface is desirable (gRPC could possibly be a nice fit) but, if done,
will come later.

This is a massive simplification that will allow for upcoming changes to
the way the reconfiguration protocol works.