### PR TITLE
Split the reconfiguration protocol into individual map/unmap operations

### DIFF
--- a/cmd/sandboxfs/sandboxfs.1
+++ b/cmd/sandboxfs/sandboxfs.1
@@ -11,7 +11,7 @@
 .\" WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 .\" License for the specific language governing permissions and limitations
 .\" under the License.
-.Dd February 27, 2018
+.Dd February 28, 2018
 .Dt SANDBOXFS 1
 .Os
 .Sh NAME
@@ -230,6 +230,8 @@ listens for reconfiguration requests on the file specified by
 .Fl -input
 and writes confirmations to the file specified by
 .Fl -output .
+These two files essentially implement a rudimentary RPC system subject to
+change.
 .Pp
 The mount point can be configured any number of times while mounted,
 which allows for processes to efficiently change the view of the sandbox at will
@@ -254,14 +256,35 @@ requests when you know that the file system is quiescent.
 .Pp
 Configuration requests are formatted as a JSON map followed by a single blank
 line.
-Each entry in the ordered map specifies a single mapping specification, with the
-following keys:
+A configuration request is an ordered sequence of
+.Em steps .
+A step is a dictionary with keys
+.Sq Map
+and
+.Sq Unmap
+which represent a single map or unmap operation.
+Exactly one key must be present in each step.
+Map operations add new mappings to the file system and unmap operations remove
+existing mappings.
+.Pp
+A map operation is specified as a dictionary with the following keys:
 .Sq Mapping
 and
 .Sq Target ,
 which define the mapping paths, and
 .Sq Writable ,
 which if set to true indicates a read/write mapping.
+The mapping must not yet exist in the file system.
+.Pp
+An unmap operation is specified as a non-empty string containing the path of
+the mapping to remove.
+The path must exist in the file system and must represent a mapping (not a file
+from an underlying file system).
+If a mapping operation created intermediate empty directory components,
+unmapping the leaf of such path does
+.Em not
+cause those intermediate components to be unmapped: it is the responsibility of
+the caller to do so, for simplicity reasons.
 .Pp
 Once
 .Nm
@@ -297,12 +320,16 @@ to point into a sandbox-specific writable directory:
 sandboxfs --mapping=ro:/:/ --mapping=rw:/tmp:/tmp/fresh-tmp /mnt
 .Ed
 .Pp
-This same configuration can be expressed as the following JSON data and can be
-fed via the input file:
+This example modifies an existing sandbox by adding a new mapping for
+.Pa /tmp
+and redoing the mapping for
+.Pa /foo
+by pointing it at another location.
 .Bd -literal -indent
 [
-    {"Mapping": "/", "Target": "/", "Writable": true},
-    {"Mapping": "/tmp", "Target": "/tmp/fresh-tmp", "Writable": false}
+    {"Map": {"Mapping": "/tmp", "Target": "/tmp/abc", "Writable": true}},
+    {"Unmap": "/foo"},
+    {"Map": {"Mapping": "/foo/bar", "Target": "/", "Writable": false}}
 ]
 .Ed
 .Sh AUTHORS
@@ -371,4 +398,8 @@ If a FIFO is used for
 will block until a separate process opens the FIFO for writing.
 This happens even before the file system starts serving, which means the file
 system is not usable until the FIFO is opened.
+.It
+While it is possible to reconfigure the entries of the root directory of a
+running file system, it is not possible to reconfigure the root mapping itself
+to point to a different location or to change its writability properties.
 .El

--- a/cmd/sandboxfs/sandboxfs.go
+++ b/cmd/sandboxfs/sandboxfs.go
@@ -102,7 +102,7 @@ func handleSignals(mountPoint <-chan string, caughtSignal chan<- os.Signal) {
 }
 
 func serve(settings ProfileSettings, mountPoint string, options []fuse.MountOption, initialMappings []sandbox.MappingSpec, reconfigInput io.Reader, reconfigOutput io.Writer) error {
-	root, err := sandbox.CreateRoot(initialMappings)
+	root, err := sandbox.CreateRoot(nil, initialMappings)
 	if err != nil {
 		return fmt.Errorf("unable to init sandbox: %v", err)
 	}

--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -37,6 +37,5 @@ go_test(
         "//integration/utils:go_default_library",
         "//internal/sandbox:go_default_library",
         "@org_bazil_fuse//:go_default_library",
-        "@org_golang_x_net//context:go_default_library",
     ],
 )

--- a/integration/reconfiguration_test.go
+++ b/integration/reconfiguration_test.go
@@ -26,142 +26,368 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/sandboxfs/integration/utils"
-	"github.com/bazelbuild/sandboxfs/internal/sandbox"
-	"golang.org/x/net/context"
 )
 
-// jsonConfig converts a collection of sandbox mappings to the JSON structure expected by sandboxfs.
-func jsonConfig(mappings []sandbox.MappingSpec) string {
-	entries := make([]string, 0, len(mappings))
-	for _, mapping := range mappings {
-		entries = append(entries, fmt.Sprintf(`{"Mapping": "%s", "Target": "%s", "Writable": %v}`, mapping.Mapping, mapping.Target, mapping.Writable))
-	}
-	return fmt.Sprintf("[%s]\n\n", strings.Join(entries, ", "))
-}
-
-// reconfigure pushes a new configuration to the sandboxfs process and waits for acknowledgement.
-func reconfigure(input io.Writer, output *bufio.Scanner, config string) error {
+// tryReconfigure pushes a new configuration to the sandboxfs process and returns the response from
+// the process.
+func tryReconfigure(input io.Writer, output *bufio.Scanner, root string, config string) (string, error) {
+	config = strings.Replace(config, "%ROOT%", root, -1) + "\n\n"
 	n, err := io.WriteString(input, config)
 	if err != nil {
-		return fmt.Errorf("failed to send new configuration to sandboxfs: %v", err)
+		return "", fmt.Errorf("failed to send new configuration to sandboxfs: %v", err)
 	}
 	if n != len(config) {
-		return fmt.Errorf("failed to send full configuration to sandboxfs: got %d bytes, want %d bytes", n, len(config))
+		return "", fmt.Errorf("failed to send full configuration to sandboxfs: got %d bytes, want %d bytes", n, len(config))
 	}
 
 	if !output.Scan() {
 		if err := output.Err(); err != nil {
-			return fmt.Errorf("failed to read from sandboxfs's output: %v", err)
+			return "", fmt.Errorf("failed to read from sandboxfs's output: %v", err)
 		}
-		return fmt.Errorf("no data available in sandboxfs's output")
+		return "", fmt.Errorf("no data available in sandboxfs's output")
+	}
+	return output.Text(), nil
+}
+
+// reconfigure pushes a new configuration to the sandboxfs process and waits for acknowledgement.
+func reconfigure(input io.Writer, output *bufio.Scanner, root string, config string) error {
+	message, err := tryReconfigure(input, output, root, config)
+	if err != nil {
+		return err
 	}
 	doneMarker := "Done"
-	if output.Text() != doneMarker {
+	if message != doneMarker {
 		return fmt.Errorf("sandboxfs did not ack configuration: got %s, want %s", output.Text(), doneMarker)
 	}
 	return nil
 }
 
-// doReconfigurationTest checks that reconfiguration works on an already-running sandboxfs instance
-// given the handles for the input and output streams.  The way this works is by pushing a first
-// configuration to sandboxfs, checking if the configuration was accepted properly, and then
-// reconfiguring the file system in an "incompatible" manner to ensure the old file system contents
-// are invalidated and the new ones are put in place.
-func doReconfigurationTest(t *testing.T, state *utils.MountState, input io.Writer, outputReader io.Reader) {
-	output := bufio.NewScanner(outputReader)
+func TestReconfiguration_Streams(t *testing.T) {
+	reconfigureAndCheck := func(t *testing.T, state *utils.MountState, input io.Writer, outputReader io.Reader) {
+		output := bufio.NewScanner(outputReader)
 
-	utils.MustMkdirAll(t, state.RootPath("a/a"), 0755)
-	config := jsonConfig([]sandbox.MappingSpec{
-		{Mapping: "/", Target: state.RootPath(), Writable: true},
-		{Mapping: "/ro", Target: state.RootPath("a/a"), Writable: false},
-		{Mapping: "/ro/rw", Target: state.RootPath(), Writable: true},
+		utils.MustMkdirAll(t, state.RootPath("a/b"), 0755)
+		config := `[{"Map": {"Mapping": "/ro", "Target": "%ROOT%/a", "Writable": false}}]`
+		if err := reconfigure(input, output, state.RootPath(), config); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := os.Lstat(state.MountPath("ro/b")); err != nil {
+			t.Errorf("Cannot stat a/b in mount point; reconfiguration failed? Got %v", err)
+		}
+	}
+
+	// TODO(jmmv): Consider dropping stdin/stdout support as defaults.  This is quite an
+	// artificial construct and makes our testing quite complex.
+	t.Run("Default", func(t *testing.T) {
+		stdoutReader, stdoutWriter := io.Pipe()
+		defer stdoutReader.Close() // Just in case the test fails half-way through.
+		defer stdoutWriter.Close() // Just in case the test fails half-way through.
+
+		state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr)
+		defer state.TearDown(t)
+		reconfigureAndCheck(t, state, state.Stdin, stdoutReader)
 	})
-	if err := reconfigure(input, output, config); err != nil {
-		t.Fatal(err)
-	}
 
-	if err := os.MkdirAll(state.MountPath("ro/hello"), 0755); err == nil {
-		t.Errorf("Mkdir succeeded in read-only mapping")
-	}
-	if err := os.MkdirAll(state.MountPath("ro/rw/hello"), 0755); err != nil {
-		t.Errorf("Mkdir failed in nested read-write mapping: %v", err)
-	}
-	if err := os.MkdirAll(state.MountPath("a/b/c"), 0755); err != nil {
-		t.Errorf("Mkdir failed in read-write root mapping: %v", err)
-	}
-	if err := ioutil.WriteFile(state.MountPath("a/b/c/file"), []byte("foo bar"), 0644); err != nil {
-		t.Errorf("Write failed in read-write root mapping: %v", err)
-	}
-	if err := utils.FileEquals(state.MountPath("a/b/c/file"), "foo bar"); err != nil {
-		t.Error(err)
-	}
-	if err := utils.FileEquals(state.RootPath("a/b/c/file"), "foo bar"); err != nil {
-		t.Error(err)
-	}
+	t.Run("Explicit", func(t *testing.T) {
+		tempDir, err := ioutil.TempDir("", "test")
+		if err != nil {
+			t.Fatalf("Failed to create temporary directory: %v", err)
+		}
+		defer os.RemoveAll(tempDir)
 
-	config = jsonConfig([]sandbox.MappingSpec{
-		{Mapping: "/rw/dir", Target: state.RootPath(), Writable: true},
+		inFifo := filepath.Join(tempDir, "input")
+		if err := syscall.Mkfifo(inFifo, 0600); err != nil {
+			t.Fatalf("Failed to create %s fifo: %v", inFifo, err)
+		}
+
+		outFifo := filepath.Join(tempDir, "output")
+		if err := syscall.Mkfifo(outFifo, 0600); err != nil {
+			t.Fatalf("Failed to create %s fifo: %v", outFifo, err)
+		}
+
+		state := utils.MountSetupWithOutputs(t, nil, os.Stderr, "-input="+inFifo, "-output="+outFifo)
+		defer state.TearDown(t)
+
+		input, err := os.OpenFile(inFifo, os.O_WRONLY, 0)
+		if err != nil {
+			t.Fatalf("Failed to open input fifo for writing: %v", err)
+		}
+		defer input.Close()
+
+		output, err := os.OpenFile(outFifo, os.O_RDONLY, 0)
+		if err != nil {
+			t.Fatalf("Failed to open output fifo for reading: %v", err)
+		}
+		defer output.Close()
+
+		reconfigureAndCheck(t, state, input, output)
 	})
-	if err := reconfigure(input, output, config); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.MkdirAll(state.MountPath("rw/dir/hello"), 0755); err != nil {
-		t.Errorf("Mkdir failed in read-write mapping: %v", err)
-	}
-	if _, err := os.Lstat(state.MountPath("a")); os.IsExist(err) {
-		t.Errorf("Old contents of root directory were not cleared after reconfiguration")
-	}
-	if _, err := os.Lstat(state.MountPath("ro")); os.IsExist(err) {
-		t.Errorf("Old read-only mapping was not cleared after reconfiguration")
-	}
 }
 
-// TODO(jmmv): Consider dropping stdin/stdout support as defaults.  This is quite an artificial
-// construct and makes our testing quite complex.
-func TestReconfiguration_DefaultStreams(t *testing.T) {
+func TestReconfiguration_Steps(t *testing.T) {
 	stdoutReader, stdoutWriter := io.Pipe()
 	defer stdoutReader.Close() // Just in case the test fails half-way through.
 	defer stdoutWriter.Close() // Just in case the test fails half-way through.
+	output := bufio.NewScanner(stdoutReader)
 
-	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr)
+	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "-mapping=ro:/:%ROOT%", "-mapping=rw:/initial:%ROOT%/initial")
 	defer state.TearDown(t)
-	doReconfigurationTest(t, state, state.Stdin, stdoutReader)
+
+	utils.MustMkdirAll(t, state.RootPath("some/read-only-dir"), 0755)
+	utils.MustMkdirAll(t, state.RootPath("some/read-write-dir"), 0755)
+	config := `[
+		{"Map": {"Mapping": "/ro", "Target": "%ROOT%/some/read-only-dir", "Writable": false}},
+		{"Map": {"Mapping": "/ro/rw", "Target": "%ROOT%/some/read-write-dir", "Writable": true}},
+		{"Map": {"Mapping": "/nested/dup", "Target": "%ROOT%/some/read-only-dir", "Writable": false}}
+	]`
+	if err := reconfigure(state.Stdin, output, state.RootPath(), config); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Lstat(state.MountPath("initial")); err != nil {
+		t.Errorf("Initial mapping seems to be gone; got %v", err)
+	}
+	if err := os.MkdirAll(state.MountPath("ro/hello"), 0755); err == nil {
+		t.Errorf("Mkdir succeeded in read-only mapping")
+	}
+	if _, err := os.Lstat(state.RootPath("some/read-only-dir/hello")); err == nil {
+		t.Errorf("Mkdir through read-only mapping propagated to root")
+	}
+	if err := os.MkdirAll(state.MountPath("ro/rw/hello2"), 0755); err != nil {
+		t.Errorf("Mkdir failed in nested read-write mapping: %v", err)
+	}
+	if _, err := os.Lstat(state.RootPath("some/read-write-dir/hello2")); err != nil {
+		t.Errorf("Mkdir through read-write didn't propagate to root; got %v", err)
+	}
+	if err := os.MkdirAll(state.MountPath("a"), 0755); err == nil {
+		t.Errorf("Mkdir succeeded in read-only root mapping")
+	}
+
+	config = `[
+		{"Unmap": "/ro"},
+		{"Map": {"Mapping": "/rw/dir", "Target": "%ROOT%/some/read-write-dir", "Writable": true}}
+	]`
+	if err := reconfigure(state.Stdin, output, state.RootPath(), config); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Lstat(state.MountPath("initial")); err != nil {
+		t.Errorf("Initial mapping seems to be gone; got %v", err)
+	}
+	if _, err := os.Lstat(state.MountPath("nested/dup")); err != nil {
+		t.Errorf("Previously-mapped /nested/dup seems to be gone; got %v", err)
+	}
+	if _, err := os.Lstat(state.MountPath("ro")); err == nil {
+		t.Errorf("Unmapped /ro is not gone")
+	}
+	if err := os.MkdirAll(state.MountPath("rw/dir/hello"), 0755); err != nil {
+		t.Errorf("Mkdir failed in read-write mapping: %v", err)
+	}
 }
 
-func TestReconfiguration_ExplicitStreams(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		t.Fatalf("Failed to create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+func TestReconfiguration_Unmap(t *testing.T) {
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer stdoutReader.Close() // Just in case the test fails half-way through.
+	defer stdoutWriter.Close() // Just in case the test fails half-way through.
+	output := bufio.NewScanner(stdoutReader)
 
-	inFifo := filepath.Join(tempDir, "input")
-	if err := syscall.Mkfifo(inFifo, 0600); err != nil {
-		t.Fatalf("Failed to create %s fifo: %v", inFifo, err)
-	}
-
-	outFifo := filepath.Join(tempDir, "output")
-	if err := syscall.Mkfifo(outFifo, 0600); err != nil {
-		t.Fatalf("Failed to create %s fifo: %v", outFifo, err)
-	}
-
-	state := utils.MountSetupWithOutputs(t, nil, os.Stderr, "-input="+inFifo, "-output="+outFifo)
+	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "-mapping=ro:/:%ROOT%", "-mapping=ro:/root-mapping:%ROOT%/foo", "-mapping=ro:/nested/mapping:%ROOT%/foo", "-mapping=ro:/deep/a/b/c/d:%ROOT%/foo")
 	defer state.TearDown(t)
 
-	input, err := os.OpenFile(inFifo, os.O_WRONLY, 0)
-	if err != nil {
-		t.Fatalf("Failed to open input fifo for writing: %v", err)
+	config := `[
+		{"Unmap": "/root-mapping"},
+		{"Unmap": "/nested/mapping"},
+		{"Unmap": "/deep/a"}
+	]`
+	if err := reconfigure(state.Stdin, output, state.RootPath(), config); err != nil {
+		t.Fatal(err)
 	}
-	defer input.Close()
-
-	output, err := os.OpenFile(outFifo, os.O_RDONLY, 0)
-	if err != nil {
-		t.Fatalf("Failed to open output fifo for reading: %v", err)
+	for _, path := range []string{"/root-mapping", "/nested/mapping", "/deep/a/b/c/d", "/deep/a/b/c", "/deep/a/b"} {
+		if _, err := os.Lstat(state.MountPath(path)); err == nil {
+			t.Errorf("Unmapped %s is not gone", path)
+		}
 	}
-	defer output.Close()
+	for _, path := range []string{"/nested", "/deep"} {
+		if _, err := os.Lstat(state.MountPath(path)); err != nil {
+			t.Errorf("Mapping %s should have been left untouched but was removed; got %v", path, err)
+		}
+	}
 
-	doReconfigurationTest(t, state, input, output)
+	config = `[{"Unmap": "/nested"}]`
+	if err := reconfigure(state.Stdin, output, state.RootPath(), config); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(state.MountPath("nested")); err == nil {
+		t.Errorf("Unmapped nested mapping is not gone")
+	}
+}
+
+func TestReconfiguration_RemapInvalidatesCache(t *testing.T) {
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer stdoutReader.Close() // Just in case the test fails half-way through.
+	defer stdoutWriter.Close() // Just in case the test fails half-way through.
+	output := bufio.NewScanner(stdoutReader)
+
+	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "-mapping=ro:/:%ROOT%")
+	defer state.TearDown(t)
+
+	checkMountPoint := func(wantExist string, wantNotExist string, wantFileContents string, wantLink string) {
+		for _, subdir := range []string{"", "/z"} {
+			if _, err := os.Lstat(state.MountPath(subdir, wantExist)); err != nil {
+				t.Errorf("%s not present: %v", filepath.Join(subdir, wantExist), err)
+			}
+			if _, err := os.Lstat(state.MountPath(subdir, wantNotExist)); wantNotExist != "" && err == nil {
+				t.Errorf("%s present but should not have been", filepath.Join(subdir, wantNotExist))
+			}
+			if err := utils.FileEquals(state.MountPath(subdir, "file"), wantFileContents); err != nil {
+				t.Errorf("%s does not match expected contents: %v", filepath.Join(subdir, "file"), err)
+			}
+			if link, err := os.Readlink(state.MountPath(subdir, "symlink")); err != nil {
+				t.Errorf("%s not present: %v", filepath.Join(subdir, "symlink"), err)
+			} else {
+				if link != wantLink {
+					t.Errorf("%s contents are invalid: got %s, want %s", filepath.Join(subdir, "symlink"), link, wantLink)
+				}
+			}
+		}
+	}
+
+	utils.MustMkdirAll(t, state.RootPath("dir"), 0755)
+	utils.MustMkdirAll(t, state.RootPath("dir/original-entry"), 0755)
+	utils.MustWriteFile(t, state.RootPath("file"), 0644, "original file contents")
+	utils.MustSymlink(t, "/non-existent", state.RootPath("symlink"))
+
+	config := `[
+		{"Map": {"Mapping": "/dir", "Target": "%ROOT%/dir", "Writable": false}},
+		{"Map": {"Mapping": "/file", "Target": "%ROOT%/file", "Writable": false}},
+		{"Map": {"Mapping": "/symlink", "Target": "%ROOT%/symlink", "Writable": false}},
+		{"Map": {"Mapping": "/z/dir", "Target": "%ROOT%/dir", "Writable": false}},
+		{"Map": {"Mapping": "/z/file", "Target": "%ROOT%/file", "Writable": false}},
+		{"Map": {"Mapping": "/z/symlink", "Target": "%ROOT%/symlink", "Writable": false}}
+	]`
+	if err := reconfigure(state.Stdin, output, state.RootPath(), config); err != nil {
+		t.Fatal(err)
+	}
+	checkMountPoint("dir/original-entry", "", "original file contents", "/non-existent")
+
+	for _, file := range []string{"dir/original-entry", "file", "symlink"} {
+		if err := os.Remove(state.RootPath(file)); err != nil {
+			t.Fatalf("Failed to remove %s while recreating files: %v", file, err)
+		}
+	}
+	utils.MustMkdirAll(t, state.RootPath("dir/new-entry"), 0755)
+	utils.MustWriteFile(t, state.RootPath("file"), 0644, "new file contents")
+	utils.MustSymlink(t, "/non-existent-other", state.RootPath("symlink"))
+
+	config = `[
+		{"Unmap": "/dir"},
+		{"Map": {"Mapping": "/dir", "Target": "%ROOT%/dir", "Writable": false}},
+		{"Unmap": "/file"},
+		{"Map": {"Mapping": "/file", "Target": "%ROOT%/file", "Writable": false}},
+		{"Unmap": "/symlink"},
+		{"Map": {"Mapping": "/symlink", "Target": "%ROOT%/symlink", "Writable": false}},
+		{"Unmap": "/z/dir"},
+		{"Map": {"Mapping": "/z/dir", "Target": "%ROOT%/dir", "Writable": false}},
+		{"Unmap": "/z/file"},
+		{"Map": {"Mapping": "/z/file", "Target": "%ROOT%/file", "Writable": false}},
+		{"Unmap": "/z/symlink"},
+		{"Map": {"Mapping": "/z/symlink", "Target": "%ROOT%/symlink", "Writable": false}}
+	]`
+	if err := reconfigure(state.Stdin, output, state.RootPath(), config); err != nil {
+		t.Fatal(err)
+	}
+	checkMountPoint("dir/new-entry", "dir/original-entry", "new file contents", "/non-existent-other")
+}
+
+func TestReconfiguration_Errors(t *testing.T) {
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer stdoutReader.Close() // Just in case the test fails half-way through.
+	defer stdoutWriter.Close() // Just in case the test fails half-way through.
+	output := bufio.NewScanner(stdoutReader)
+
+	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "-mapping=rw:/:%ROOT%")
+	defer state.TearDown(t)
+
+	utils.MustMkdirAll(t, state.RootPath("subdir"), 0755)
+	utils.MustWriteFile(t, state.RootPath("file"), 0644, "")
+
+	testData := []struct {
+		name string
+
+		config    string
+		wantError string
+	}{
+		{
+			"InvalidSyntax",
+			`this is not in the correct format`,
+			"unable to parse json",
+		},
+		{
+			"InvalidMapping",
+			`[{"Map": {"Mapping": "foo/../.", "Target": "%ROOT%/subdir", "Writable": false}}]`,
+			"invalid mapping foo/../.: empty path",
+		},
+		{
+			"EmptyStep",
+			`[{}]`,
+			"neither Map nor Unmap were defined",
+		},
+		{
+			"MapAndUnmapInSameStep",
+			`[{"Map": {"Mapping": "/foo", "Target": "%ROOT%", "Writable": false}, "Unmap": "/bar"}]`,
+			"Map and Unmap are exclusive",
+		},
+		{
+			"RemapRoot",
+			`[{"Map": {"Mapping": "/", "Target": "%ROOT%/subdir", "Writable": false}}]`,
+			"root.*not more than once",
+		},
+		{
+			"MapTwice",
+			`[{"Map": {"Mapping": "/foo", "Target": "%ROOT%/subdir", "Writable": false}}, {"Map": {"Mapping": "/foo", "Target": "%ROOT%/file", "Writable": false}}]`,
+			"already mapped",
+		},
+		{
+			"UnmapRoot",
+			`[{"Unmap": "/"}]`,
+			"cannot unmap root",
+		},
+		{
+			"UnmapRealUnmappedFile",
+			`[{"Unmap": "/file"}]`,
+			"not a mapping",
+		},
+		{
+			"UnmapMissingEntryInMapping",
+			`[{"Map": {"Mapping": "/subdir", "Target": "%ROOT%/subdir", "Writable": false}}, {"Unmap": "/subdir/foo"}]`,
+			"leaf foo not mapped",
+		},
+		{
+			"UnmapMissingEntryInRealUnmappedDirectory",
+			`[{"Unmap": "/subdir/foo"}]`,
+			"leaf foo not mapped",
+		},
+		{
+			"UnmapPathWithMissingComponents",
+			`[{"Unmap": "/missing/long/path"}]`,
+			"intermediate components not mapped",
+		},
+	}
+	for _, d := range testData {
+		t.Run(d.name, func(t *testing.T) {
+			message, err := tryReconfigure(state.Stdin, output, state.RootPath(), d.config)
+			if err != nil {
+				t.Fatalf("want reconfiguration of / to fail; got success")
+			}
+			if !utils.MatchesRegexp(d.wantError, message) {
+				t.Errorf("want reconfiguration to respond with %s; got %s", d.wantError, message)
+			}
+			if _, err := os.Lstat(state.MountPath("file")); err != nil {
+				t.Errorf("want file to still exist after failed reconfiguration; got %v", err)
+			}
+		})
+	}
 }
 
 func TestReconfiguration_RaceSystemComponents(t *testing.T) {
@@ -191,10 +417,8 @@ func TestReconfiguration_RaceSystemComponents(t *testing.T) {
 
 		utils.MustWriteFile(t, state.RootPath("first"), 0644, "First")
 
-		firstConfig := jsonConfig([]sandbox.MappingSpec{
-			{Mapping: "/first", Target: state.RootPath("first"), Writable: false},
-		})
-		if err := reconfigure(state.Stdin, output, firstConfig); err != nil {
+		firstConfig := `[{"Map": {"Mapping": "/first", "Target": "%ROOT%/first", "Writable": false}}]`
+		if err := reconfigure(state.Stdin, output, state.RootPath(), firstConfig); err != nil {
 			state.TearDown(t)
 			return err
 		}
@@ -241,10 +465,8 @@ func TestReconfiguration_DirectoryListings(t *testing.T) {
 			utils.MustMkdirAll(t, state.RootPath("dir2"), 0755)
 			utils.MustWriteFile(t, state.RootPath("dir2/second"), 0644, "Second")
 
-			firstConfig := jsonConfig([]sandbox.MappingSpec{
-				{Mapping: filepath.Join(d.dir, "first"), Target: state.RootPath(d.firstConfigTarget), Writable: false},
-			})
-			if err := reconfigure(state.Stdin, output, firstConfig); err != nil {
+			firstConfig := fmt.Sprintf(`[{"Map": {"Mapping": "%s", "Target": "%s", "Writable": false}}]`, filepath.Join(d.dir, "first"), state.RootPath(d.firstConfigTarget))
+			if err := reconfigure(state.Stdin, output, state.RootPath(), firstConfig); err != nil {
 				t.Fatalf("First configuration failed: %v", err)
 			}
 			if err := utils.DirEntryNamesEqual(state.MountPath(d.dir), []string{"first"}); err != nil {
@@ -262,10 +484,11 @@ func TestReconfiguration_DirectoryListings(t *testing.T) {
 				defer handle.Close()
 			}
 
-			secondConfig := jsonConfig([]sandbox.MappingSpec{
-				{Mapping: filepath.Join(d.dir, "second"), Target: state.RootPath(d.secondConfigTarget), Writable: false},
-			})
-			if err := reconfigure(state.Stdin, output, secondConfig); err != nil {
+			secondConfig := fmt.Sprintf(`[
+				{"Unmap": "%s"},
+				{"Map": {"Mapping": "%s", "Target": "%s", "Writable": false}}
+			]`, filepath.Join(d.dir, "first"), filepath.Join(d.dir, "second"), state.RootPath(d.secondConfigTarget))
+			if err := reconfigure(state.Stdin, output, state.RootPath(), secondConfig); err != nil {
 				t.Fatalf("Second configuration failed: %v", err)
 			}
 			if err := utils.DirEntryNamesEqual(state.MountPath(d.dir), []string{"second"}); err != nil {
@@ -302,11 +525,11 @@ func TestReconfiguration_InodesAreStableForSameUnderlyingFiles(t *testing.T) {
 
 	wantInodes := make(map[string]uint64)
 
-	firstConfig := jsonConfig([]sandbox.MappingSpec{
-		{Mapping: "/dir1", Target: state.RootPath("dir1"), Writable: false},
-		{Mapping: "/dir3", Target: state.RootPath("dir3"), Writable: false},
-	})
-	if err := reconfigure(state.Stdin, output, firstConfig); err != nil {
+	firstConfig := `[
+		{"Map": {"Mapping": "/dir1", "Target": "%ROOT%/dir1", "Writable": false}},
+		{"Map": {"Mapping": "/dir3", "Target": "%ROOT%/dir3", "Writable": false}}
+	]`
+	if err := reconfigure(state.Stdin, output, state.RootPath(), firstConfig); err != nil {
 		t.Fatalf("First configuration failed: %v", err)
 	}
 	wantInodes["dir1"] = inodeOf(state.MountPath("dir1"))
@@ -314,16 +537,18 @@ func TestReconfiguration_InodesAreStableForSameUnderlyingFiles(t *testing.T) {
 	wantInodes["dir3"] = inodeOf(state.MountPath("dir3"))
 	wantInodes["dir3/file"] = inodeOf(state.MountPath("dir3/file"))
 
-	secondConfig := jsonConfig([]sandbox.MappingSpec{
-		{Mapping: "/dir2", Target: state.RootPath("dir2"), Writable: false},
-	})
-	if err := reconfigure(state.Stdin, output, secondConfig); err != nil {
+	secondConfig := `[
+		{"Unmap": "/dir1"},
+		{"Unmap": "/dir3"},
+		{"Map": {"Mapping": "/dir2", "Target": "%ROOT%/dir2", "Writable": false}}
+	]`
+	if err := reconfigure(state.Stdin, output, state.RootPath(), secondConfig); err != nil {
 		t.Fatalf("Failed to replace all mappings with new configuration: %v", err)
 	}
 	wantInodes["dir2"] = inodeOf(state.MountPath("dir2"))
 	wantInodes["dir2/file"] = inodeOf(state.MountPath("dir2/file"))
 
-	if err := reconfigure(state.Stdin, output, firstConfig); err != nil {
+	if err := reconfigure(state.Stdin, output, state.RootPath(), firstConfig); err != nil {
 		t.Fatalf("Failed to restore all mappings from first configuration: %v", err)
 	}
 
@@ -363,10 +588,8 @@ func TestReconfiguration_WritableNodesAreDifferent(t *testing.T) {
 
 	utils.MustMkdirAll(t, state.RootPath("dir1"), 0755)
 
-	config := jsonConfig([]sandbox.MappingSpec{
-		{Mapping: "/dir1", Target: state.RootPath("dir1"), Writable: true},
-	})
-	if err := reconfigure(state.Stdin, output, config); err != nil {
+	config := `[{"Map": {"Mapping": "/dir1", "Target": "%ROOT%/dir1", "Writable": true}}]`
+	if err := reconfigure(state.Stdin, output, state.RootPath(), config); err != nil {
 		t.Fatal(err)
 	}
 
@@ -374,10 +597,11 @@ func TestReconfiguration_WritableNodesAreDifferent(t *testing.T) {
 		t.Errorf("Failed to create entry in writable directory: %v", err)
 	}
 
-	config = jsonConfig([]sandbox.MappingSpec{
-		{Mapping: "/dir1", Target: state.RootPath("dir1"), Writable: false},
-	})
-	if err := reconfigure(state.Stdin, output, config); err != nil {
+	config = `[
+		{"Unmap": "/dir1"},
+		{"Map": {"Mapping": "/dir1", "Target": "%ROOT%/dir1", "Writable": false}}
+	]`
+	if err := reconfigure(state.Stdin, output, state.RootPath(), config); err != nil {
 		t.Fatal(err)
 	}
 
@@ -426,10 +650,8 @@ func TestReconfiguration_FileSystemStillWorksAfterInputEOF(t *testing.T) {
 	go grepStderr(stderrReader, `reached end of input`, gotEOF)
 
 	utils.MustMkdirAll(t, state.RootPath("dir"), 0755)
-	config := jsonConfig([]sandbox.MappingSpec{
-		{Mapping: "/dir", Target: state.RootPath("dir"), Writable: true},
-	})
-	if err := reconfigure(state.Stdin, output, config); err != nil {
+	config := `[{"Map": {"Mapping": "/dir", "Target": "%ROOT%/dir", "Writable": true}}]`
+	if err := reconfigure(state.Stdin, output, state.RootPath(), config); err != nil {
 		t.Fatal(err)
 	}
 
@@ -487,108 +709,3 @@ func TestReconfiguration_StreamFileDoesNotExist(t *testing.T) {
 		})
 	}
 }
-
-func TestReconfiguration_InvalidationsRaceWithWrites(t *testing.T) {
-	// This is a race-condition test: we attempt to mutate the in-memory nodes of the file
-	// system while reconfiguration operations are in-progress to ensure that handling those
-	// reconfigurations doesn't collide with the mutations.  Given that this tries to exercise a
-	// race condition, a success in this test does not imply that things work correctly, but a
-	// failure is a conclusive indication of a real bug.
-	//
-	// The way we exercise this race is: first, we create a large number of files and expose
-	// them through sandboxfs.  We then issue individual Lookup operations on each file (by
-	// reading the files by name, *NOT* by doing a ReadDir), which internally must update the
-	// contents of the directory known so far.  Concurrently, we hammer the sandboxfs process
-	// with reconfiguration requests.  If all goes well, all reads should succeed and sandboxfs
-	// should exit cleanly; any other outcome is a failure.
-
-	// createEntries fills the given directory with n files named [0..n-1].
-	createEntries := func(dir string, n int) {
-		for i := 0; i < n; i++ {
-			path := filepath.Join(dir, fmt.Sprintf("%d", i))
-			if err := ioutil.WriteFile(path, []byte{}, 0644); err != nil {
-				t.Errorf("WriteFile of %s failed: %v", path, err)
-			}
-
-			if i%100 == 0 {
-				t.Logf("Done creating %d files", i)
-			}
-		}
-	}
-
-	// readEntries reads n files named [0..n-1] from the given directory.
-	//
-	// As described above, this must not issue a ReadDir operation.  Instead, it must look up
-	// the files individually so that sandboxfs receives individual requests at the directory
-	// level for each.
-	readEntries := func(dir string, n int) {
-		for i := 0; i < n; i++ {
-			path := filepath.Join(dir, fmt.Sprintf("%d", i))
-			if _, err := ioutil.ReadFile(path); err != nil {
-				t.Errorf("ReadFile of %s failed: %v", path, err)
-			}
-
-			if i%100 == 0 {
-				t.Logf("Done looking up and reading %d files", i)
-			}
-		}
-		t.Logf("Done looking up and reading %d files", n)
-	}
-
-	// hammerReconfigurations wraps reconfigure in a tight loop to flood the file system with
-	// requests to update its configuration.  Requesting a cancellation via the context causes
-	// this to terminate, which then notifies the caller by writing to done.
-	hammerReconfigurations := func(ctx context.Context, input io.Writer, output *bufio.Scanner, config string, done chan<- bool) {
-		for i := 0; ; i++ {
-			if i%500 == 0 {
-				t.Logf("Reconfiguration number %d", i)
-			}
-
-			if err := reconfigure(input, output, config); err != nil {
-				t.Fatal(err)
-			}
-
-			select {
-			case <-ctx.Done():
-				done <- true
-				return
-			default:
-				// Just try again immediately.  We want this to be very aggressive,
-				// as we are trying to catch very subtle race problems.
-			}
-		}
-	}
-
-	stdoutReader, stdoutWriter := io.Pipe()
-	defer stdoutReader.Close()
-	defer stdoutWriter.Close()
-	output := bufio.NewScanner(stdoutReader)
-
-	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr)
-	defer state.TearDown(t)
-
-	utils.MustMkdirAll(t, state.RootPath("dir"), 0755)
-	config := jsonConfig([]sandbox.MappingSpec{
-		{Mapping: "/dir", Target: state.RootPath("dir"), Writable: false},
-	})
-
-	nEntries := 2000
-	utils.MustMkdirAll(t, state.RootPath("dir/subdir"), 0755)
-	createEntries(state.RootPath("dir/subdir"), nEntries)
-
-	if err := reconfigure(state.Stdin, output, config); err != nil {
-		t.Fatal(err)
-	}
-
-	done := make(chan bool)
-	ctx, cancel := context.WithCancel(context.Background())
-	go hammerReconfigurations(ctx, state.Stdin, output, config, done)
-	readEntries(state.MountPath("dir/subdir"), nEntries)
-	cancel()
-	<-done
-}
-
-// TODO(jmmv): Need to have tests for when the configuration is invalid (malformed JSON,
-// inconsistent mappings, etc.).  No need for these to be very detailed given that the validations
-// are already tested in "static" mode, but we must ensure that such validation paths are also
-// exercised in dynamic mode when the configuration is processed.

--- a/integration/reconfiguration_test.go
+++ b/integration/reconfiguration_test.go
@@ -361,17 +361,17 @@ func TestReconfiguration_Errors(t *testing.T) {
 		{
 			"UnmapMissingEntryInMapping",
 			`[{"Map": {"Mapping": "/subdir", "Target": "%ROOT%/subdir", "Writable": false}}, {"Unmap": "/subdir/foo"}]`,
-			"leaf foo not mapped",
+			"path not found",
 		},
 		{
 			"UnmapMissingEntryInRealUnmappedDirectory",
 			`[{"Unmap": "/subdir/foo"}]`,
-			"leaf foo not mapped",
+			"path not found",
 		},
 		{
 			"UnmapPathWithMissingComponents",
 			`[{"Unmap": "/missing/long/path"}]`,
-			"intermediate components not mapped",
+			"path not found",
 		},
 	}
 	for _, d := range testData {

--- a/internal/sandbox/dir.go
+++ b/internal/sandbox/dir.go
@@ -129,6 +129,27 @@ func (d *Dir) LookupOrCreateDirs(components []string) *Dir {
 	return child.LookupOrCreateDirs(remainder)
 }
 
+// LookupOrFail traverses a set of components and returns the directory containing the final
+// component, or nil if not found.
+func (d *Dir) LookupOrFail(components []string) *Dir {
+	if len(components) == 0 {
+		return d
+	}
+	name := components[0]
+	remainder := components[1:]
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if child, ok := d.children[name]; ok {
+		if dir, ok := child.(*Dir); ok {
+			return dir.LookupOrFail(remainder)
+		}
+		return nil
+	}
+	return nil
+}
+
 // Map registers a new directory entry as a mapping to an arbitrary node.
 //
 // This function is intended to be used during (re)configuration to set up empty directories with
@@ -141,6 +162,28 @@ func (d *Dir) Map(name string, node Node) error {
 		return fmt.Errorf("already mapped")
 	}
 	d.children[name] = node
+	return nil
+}
+
+// Unmap unregisters a directory entry and all of its descendents.
+//
+// This function is intendd to be used during reconfigurations to delete parts of the tree that
+// ought to disappear from the file system. It is OK to remap these same directory entries after
+// a successful unmap.
+func (d *Dir) Unmap(server *fs.Server, identity fs.Node, name string) error {
+	d.mu.Lock()
+	node, ok := d.children[name]
+	if !ok {
+		d.mu.Unlock()
+		return fmt.Errorf("leaf %s not mapped", name)
+	}
+	if !node.IsMapping() {
+		d.mu.Unlock()
+		return fmt.Errorf("leaf %s not a mapping", name)
+	}
+	delete(d.children, name)
+	d.mu.Unlock()
+	server.InvalidateEntry(identity, name)
 	return nil
 }
 
@@ -494,34 +537,4 @@ func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) error {
 		delete(d.children, req.Name)
 	}
 	return fuseErrno(err)
-}
-
-// invalidate clears the kernel cache for this directory and all of its entries.
-func (d *Dir) invalidate(server *fs.Server) {
-	// We assume that, as long as a Dir object is alive, the node corresponds to a
-	// non-deleted underlying directory. Therefore, do not invalidate the node itself, only its
-	// entries. This is important to keep entries alive across reconfigurations, which helps
-	// performance.
-
-	d.invalidateEntries(server, d)
-}
-
-// invalidateEntries clears the kernel cache for all entries that descend from this directory.
-//
-// The identity parameter indicates who the real owner of the entries is from the point of view of
-// the FUSE API. In the general case, identity will match v, but in the case of the root directory,
-// identity will be that of the Root node.
-func (d *Dir) invalidateEntries(server *fs.Server, identity fs.Node) {
-	d.mu.Lock()
-	entries := make(map[string]cacheInvalidator)
-	for name, node := range d.children {
-		entries[name] = node
-	}
-	d.mu.Unlock()
-
-	for name, node := range entries {
-		err := server.InvalidateEntry(identity, name)
-		logCacheInvalidationError(err, "Could not invalidate node entry: ", identity, name)
-		node.invalidate(server)
-	}
 }

--- a/internal/sandbox/file.go
+++ b/internal/sandbox/file.go
@@ -114,10 +114,3 @@ func (f *File) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
 func (o *openFile) Release(ctx context.Context, req *fuse.ReleaseRequest) error {
 	return fuseErrno(o.nativeFile.Close())
 }
-
-// invalidate clears the kernel cache corresponding to this file.
-func (f *File) invalidate(server *fs.Server) {
-	// We assume that, as long as a File object is alive, the node corresponds to a
-	// non-deleted underlying file. Therefore, do not invalidate the node itself. This is
-	// important to keep entries alive across reconfigurations, which helps performance.
-}

--- a/internal/sandbox/node.go
+++ b/internal/sandbox/node.go
@@ -162,9 +162,6 @@ type Node interface {
 
 	// delete tells the node that a directory entry pointing to it has been removed.
 	delete()
-
-	// invalidate clears the kernel cache for this node.
-	invalidate(*fs.Server)
 }
 
 // getOrCreateNode gets a mapped node from the cache or creates a new one if not yet cached.

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -46,6 +46,15 @@ type MappingSpec struct {
 	Writable bool
 }
 
+// Step represents a single reconfiguration operation.
+type Step struct {
+	// Map requests that a new mapping be added to the file system.
+	Map *MappingSpec
+
+	// Unmap requests that the given mapping is removed from the file system.
+	Unmap string
+}
+
 // nextInodeNumber returns the next unused inode number.
 func nextInodeNumber() uint64 {
 	lastInodeNumber.mu.Lock()
@@ -57,21 +66,6 @@ func nextInodeNumber() uint64 {
 // FS is the global unique representation of the filesystem tree.
 type FS struct {
 	root *Root
-}
-
-// Reconfigure resets the tree under this node to the new configuration.
-func (f *FS) Reconfigure(server *fs.Server, root *Dir) {
-	// TODO(pallavag): Right now, we do not reuse inode numbers, because it is
-	// uncertain if doing so would be valid from a correctness perspective.
-	// Once the code has been well tested, it may be worthwile to try resetting
-	// the inode counter at this location.
-	// Also, it may be desirable to keep a track of all open file handles, and
-	// close them before reconfiguration. Alternatively, we may want to close
-	// only the handles that no longer appear in the new configuration, or are
-	// relocated. Or just disallow reconfiguration when there are open file
-	// handles. Needs more thought; think about what happens when one tries to
-	// unmount a file system with open handles.
-	f.root.Reconfigure(server, root)
 }
 
 // readConfig reads one chunk of config from reader.
@@ -94,7 +88,7 @@ func readConfig(reader *bufio.Reader) ([]byte, error) {
 // initFromReader initializes a filesystem configuration after reading the config from the passed
 // reader.  Reaching EOF on the reader causes this function to return io.EOF, which the caller
 // must handle gracefully.
-func initFromReader(reader *bufio.Reader) (*Dir, error) {
+func initFromReader(reader *bufio.Reader) ([]Step, error) {
 	configRead, err := readConfig(reader)
 	if err != nil {
 		if err == io.EOF {
@@ -102,15 +96,11 @@ func initFromReader(reader *bufio.Reader) (*Dir, error) {
 		}
 		return nil, fmt.Errorf("unable to read config: %v", err)
 	}
-	configArgs := make([]MappingSpec, 0)
-	if err := json.Unmarshal(configRead, &configArgs); err != nil {
+	steps := []Step{}
+	if err := json.Unmarshal(configRead, &steps); err != nil {
 		return nil, fmt.Errorf("unable to parse json: %v", err)
 	}
-	sfs, err := CreateRoot(configArgs)
-	if err != nil {
-		return nil, fmt.Errorf("sandbox init failed with: %v", err)
-	}
-	return sfs, nil
+	return steps, nil
 }
 
 // reconfigurationListener monitors the input for a configuration, and
@@ -118,7 +108,7 @@ func initFromReader(reader *bufio.Reader) (*Dir, error) {
 func reconfigurationListener(server *fs.Server, filesystem *FS, input io.Reader, output io.Writer) {
 	reader := bufio.NewReader(input)
 	for {
-		sfs, err := initFromReader(reader)
+		config, err := initFromReader(reader)
 		if err != nil {
 			if err == io.EOF {
 				break
@@ -126,7 +116,10 @@ func reconfigurationListener(server *fs.Server, filesystem *FS, input io.Reader,
 			fmt.Fprintf(output, "Reconfig failed: %v\n", err)
 			continue
 		}
-		filesystem.Reconfigure(server, sfs)
+		if err := filesystem.Reconfigure(server, config); err != nil {
+			fmt.Fprintf(output, "Reconfig failed: %v\n", err)
+			continue
+		}
 		fmt.Fprintln(output, "Done")
 	}
 	log.Printf("reached end of input during reconfiguration; file system will continue running until unmounted")
@@ -172,40 +165,137 @@ func tokenizePath(path string) []string {
 	return tokens
 }
 
-// CreateRoot generates a directory tree to represent the given mappings.
-func CreateRoot(mappings []MappingSpec) (*Dir, error) {
-	var root *Dir
-	for _, mapping := range mappings {
-		components := tokenizePath(mapping.Mapping)
-		if len(components) == 0 {
-			return nil, fmt.Errorf("invalid mapping %s: empty path", mapping.Mapping)
-		} else if components[0] != "" {
-			return nil, fmt.Errorf("invalid mapping %s: must be an absolute path", mapping.Mapping)
-		} else if len(components) == 1 && root != nil {
-			return nil, fmt.Errorf("failed to map root with target %s: root must be mapped first and not more than once", mapping.Target)
-		}
+// tokenizeMapping builds upon tokenizePath to split a path into its components and validate that
+// the result is a valid mapping.
+func tokenizeMapping(path string) ([]string, error) {
+	components := tokenizePath(path)
+	if len(components) == 0 {
+		return nil, fmt.Errorf("invalid mapping %s: empty path", path)
+	} else if components[0] != "" {
+		return nil, fmt.Errorf("invalid mapping %s: must be an absolute path", path)
+	}
+	return components, nil
+}
 
-		fileInfo, err := os.Lstat(mapping.Target)
-		if err != nil {
-			return nil, fmt.Errorf("failed to stat %s when mapping %s: %v", mapping.Target, mapping.Mapping, err)
-		}
+// applyMapping adds a new mapping to the given root directory.  If the root directory is nil and
+// the mapping is valid, this returns a newly-instantiated root directory; otherwise, the returned
+// root directory matches the input root directory.
+func applyMapping(root *Dir, mapping *MappingSpec) (*Dir, error) {
+	components, err := tokenizeMapping(mapping.Mapping)
+	if err != nil {
+		return nil, err
+	}
+	if len(components) == 1 && root != nil {
+		return nil, fmt.Errorf("failed to map root with target %s: root must be mapped first and not more than once", mapping.Target)
+	}
 
-		if len(components) == 1 {
-			if fileInfo.Mode()&os.ModeType != os.ModeDir {
-				return nil, fmt.Errorf("cannot map file %s at root: must be a directory", mapping.Target)
+	fileInfo, err := os.Lstat(mapping.Target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat %s when mapping %s: %v", mapping.Target, mapping.Mapping, err)
+	}
+
+	if len(components) == 1 {
+		if fileInfo.Mode()&os.ModeType != os.ModeDir {
+			return nil, fmt.Errorf("cannot map file %s at root: must be a directory", mapping.Target)
+		}
+		root = newDir(mapping.Target, fileInfo, mapping.Writable)
+		root.isMapping = true
+	} else {
+		if root == nil {
+			root = newDirEmpty()
+		}
+		dirNode := root.LookupOrCreateDirs(components[1 : len(components)-1])
+		newNode := getOrCreateNode(mapping.Target, fileInfo, mapping.Writable)
+		newNode.SetIsMapping()
+		if err := dirNode.Map(components[len(components)-1], newNode); err != nil {
+			return nil, fmt.Errorf("cannot map %s: %v", mapping.Mapping, err)
+		}
+	}
+	return root, nil
+}
+
+// reconfigureMap applies a single Map step to the file system.
+func (f *FS) reconfigureMap(mapping *MappingSpec) error {
+	// TODO(jmmv): We cheat and peek directly into root to get its directory.  The directory
+	// could change with previous implementations of reconfiguration but cannot any longer.
+	// Remove once the Root node indirection is gone.
+	root := f.root.getDir()
+	newRoot, err := applyMapping(root, mapping)
+	if err != nil {
+		return err
+	}
+	if root != newRoot {
+		// applyMapping above has the ability to generate a new root directory when none is
+		// given to it.  We should never encounter that situation here because we do not
+		// allow mapping reconfigurations to modify the root, so ensure this is true.
+		panic("Mapping should not have changed the root but did")
+	}
+	return nil
+}
+
+// reconfigureUnmap applies a single Unmap step to the file system.
+//
+// Note that this only removes the leaf of the given mapping: nested entries created during a map
+// operation are left behind and have to be unmapped explicitly.  E.g. if /foo/bar/baz was mapped
+// on an empty file system, /foo/bar are two intermediate mappings that are not removed when
+// /foo/var/baz is unmapped.  This is for simplicity as we'd otherwise need to track whether a
+// mapping was explicitly created by the user or as a result of another mapping, and also to keep
+// the unmapping algorithm trivial.
+func (f *FS) reconfigureUnmap(server *fs.Server, mapping string) error {
+	components, err := tokenizeMapping(mapping)
+	if err != nil {
+		return err
+	}
+	if len(components) == 1 {
+		return fmt.Errorf("cannot unmap root")
+	}
+	node := f.root.dir.LookupOrFail(components[1 : len(components)-1])
+	if node == nil {
+		return fmt.Errorf("failed to unmap %s: intermediate components not mapped", mapping)
+	}
+	// TODO(jmmv): Determining the "identity" of the node exists purely to deal with the fact
+	// that Root is a container for a directory that could mutate with previous implementations
+	// of reconfiguration.  Remove the Root indirection and this hack.
+	var identity fs.Node
+	identity = f.root
+	if len(components) > 2 {
+		identity = node
+	}
+	if err := node.Unmap(server, identity, components[len(components)-1]); err != nil {
+		return fmt.Errorf("failed to unmap %s: %v", mapping, err)
+	}
+	return nil
+}
+
+// Reconfigure applies a reconfiguration request to the file system.
+func (f *FS) Reconfigure(server *fs.Server, steps []Step) error {
+	// TODO(jmmv): This essentially implements an RPC system with two functions.  Investigate
+	// whether we can replace this with local gRPC (re. performance).
+	for _, step := range steps {
+		if step.Map != nil && step.Unmap != "" {
+			return fmt.Errorf("invalid step: Map and Unmap are exclusive")
+		} else if step.Map != nil {
+			if err := f.reconfigureMap(step.Map); err != nil {
+				return err
 			}
-			root = newDir(mapping.Target, fileInfo, mapping.Writable)
-			root.isMapping = true
+		} else if step.Unmap != "" {
+			if err := f.reconfigureUnmap(server, step.Unmap); err != nil {
+				return err
+			}
 		} else {
-			if root == nil {
-				root = newDirEmpty()
-			}
-			dirNode := root.LookupOrCreateDirs(components[1 : len(components)-1])
-			newNode := getOrCreateNode(mapping.Target, fileInfo, mapping.Writable)
-			newNode.SetIsMapping()
-			if err := dirNode.Map(components[len(components)-1], newNode); err != nil {
-				return nil, fmt.Errorf("cannot map %s: %v", mapping.Mapping, err)
-			}
+			return fmt.Errorf("invalid step: neither Map nor Unmap were defined")
+		}
+	}
+	return nil
+}
+
+// CreateRoot generates a directory tree to represent the given mappings.
+func CreateRoot(root *Dir, mappings []MappingSpec) (*Dir, error) {
+	for _, mapping := range mappings {
+		var err error
+		root, err = applyMapping(root, &mapping)
+		if err != nil {
+			return nil, err
 		}
 	}
 	if root == nil {
@@ -257,15 +347,6 @@ func fuseErrno(e error) error {
 		return fuse.Errno(syscall.EBADF)
 	}
 	return e
-}
-
-func logCacheInvalidationError(e error, info ...interface{}) {
-	switch e {
-	case nil, fuse.ErrNotCached: // ignored errors
-		return
-	}
-	info = append(info, ": ", e)
-	log.Print(info...)
 }
 
 // UnixMode translates a Go os.FileMode to a Unix mode.

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -249,9 +249,9 @@ func (f *FS) reconfigureUnmap(server *fs.Server, mapping string) error {
 	if len(components) == 1 {
 		return fmt.Errorf("cannot unmap root")
 	}
-	node := f.root.dir.LookupOrFail(components[1 : len(components)-1])
+	node := f.root.dir.LookupOrFail(components[1:])
 	if node == nil {
-		return fmt.Errorf("failed to unmap %s: intermediate components not mapped", mapping)
+		return fmt.Errorf("failed to unmap %s: path not found", mapping)
 	}
 	// TODO(jmmv): Determining the "identity" of the node exists purely to deal with the fact
 	// that Root is a container for a directory that could mutate with previous implementations

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -190,7 +190,7 @@ func TestCreateRoot_Ok(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.name, func(t *testing.T) {
-			root, err := CreateRoot(d.mappings)
+			root, err := CreateRoot(nil, d.mappings)
 			if err != nil {
 				t.Fatalf("Failed to create hierarchy: %v", err)
 			}
@@ -247,7 +247,7 @@ func TestCreateRoot_Errors(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.name, func(t *testing.T) {
-			_, err := CreateRoot(d.mappings)
+			_, err := CreateRoot(nil, d.mappings)
 			if err == nil {
 				t.Errorf("want error to match %s; got no error", d.wantErr)
 			} else {

--- a/internal/sandbox/symlink.go
+++ b/internal/sandbox/symlink.go
@@ -18,7 +18,6 @@ import (
 	"os"
 
 	"bazil.org/fuse"
-	"bazil.org/fuse/fs"
 	"golang.org/x/net/context"
 )
 
@@ -56,11 +55,4 @@ func (s *Symlink) Dirent(name string) fuse.Dirent {
 		Name:  name,
 		Type:  fuse.DT_Link,
 	}
-}
-
-// invalidate clears the kernel cache corresponding to this symlink.
-func (s *Symlink) invalidate(server *fs.Server) {
-	// We assume that, as long as a Symlink object is alive, the node corresponds to a
-	// non-deleted underlying symlink. Therefore, do not invalidate the node itself. This is
-	// important to keep entries alive across reconfigurations, which helps performance.
 }


### PR DESCRIPTION
The previous sandboxfs exposed a mechanism to change the whole file
system contents "at once" (though not atomically).  This was problematic
because sandboxfs couldn't make any assurances about items being
replaced.

What's worse is that the previous approach made it very hard for Bazel
to share a single sandboxfs instance for different actions.  We'd like
to have each action run in a subdirectory of sandboxfs, but changing
the views of these directories without interfering others was not
possible.  (Bazel could have maintained a full list of all the mappings
and then fed this whole list to sandboxfs for each action... but that's
costly, and due to our poor reconfiguration algorithm, this caused
interference for entries that were supposed to remain unchanged.)

To make this all simpler, change the reconfiguration protocol so that
the user feeds a series of ordered steps to map and unmap independent
entries.  For Bazel, this trivially allows using different top-level
subdirectories for each action.  For other users... this may not be
great, but we don't care for now.  If we want to offer full
reconfigurations at a later stage, we can do so again.