### PR TITLE
Make sure all flag names start with --

### DIFF
--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -24,7 +24,7 @@ import (
 func TestDebug_FuseOpsInLog(t *testing.T) {
 	stderr := new(bytes.Buffer)
 
-	state := utils.MountSetupWithOutputs(t, nil, stderr, "--debug", "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetupWithOutputs(t, nil, stderr, "--debug", "--mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("cookie"), 0644, "")

--- a/integration/nesting_test.go
+++ b/integration/nesting_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestNesting_ScaffoldIntermediateComponents(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%", "-mapping=ro:/1/2/3/4/5:%ROOT%/subdir")
+	state := utils.MountSetup(t, "--mapping=ro:/:%ROOT%", "--mapping=ro:/1/2/3/4/5:%ROOT%/subdir")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("subdir", "file"), 0644, "some contents")
@@ -59,7 +59,7 @@ func TestNesting_ScaffoldIntermediateComponentsAreImmutable(t *testing.T) {
 	// attempt real writes.
 	root := utils.RequireRoot(t, "Requires root privileges to write to directories with mode 0555")
 
-	state := utils.MountSetupWithUser(t, root, "-mapping=ro:/:%ROOT%", "-mapping=rw:/1/2/3:%ROOT%/subdir")
+	state := utils.MountSetupWithUser(t, root, "--mapping=ro:/:%ROOT%", "--mapping=rw:/1/2/3:%ROOT%/subdir")
 	defer state.TearDown(t)
 
 	for _, dir := range []string{"1/foo", "1/2/foo"} {
@@ -75,7 +75,7 @@ func TestNesting_ScaffoldIntermediateComponentsAreImmutable(t *testing.T) {
 }
 
 func TestNesting_ReadWriteWithinReadOnly(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%", "-mapping=ro:/ro:%ROOT%/one/two", "-mapping=rw:/ro/rw:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%", "--mapping=ro:/ro:%ROOT%/one/two", "--mapping=rw:/ro/rw:%ROOT%")
 	defer state.TearDown(t)
 
 	if err := os.MkdirAll(state.MountPath("ro/hello"), 0755); err == nil {
@@ -87,7 +87,7 @@ func TestNesting_ReadWriteWithinReadOnly(t *testing.T) {
 }
 
 func TestNesting_SameTarget(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%", "-mapping=rw:/dir1:%ROOT%/same", "-mapping=rw:/dir2/dir3/dir4:%ROOT%/same")
+	state := utils.MountSetup(t, "--mapping=ro:/:%ROOT%", "--mapping=rw:/dir1:%ROOT%/same", "--mapping=rw:/dir2/dir3/dir4:%ROOT%/same")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.MountPath("dir1/file"), 0644, "old contents")
@@ -117,7 +117,7 @@ func TestNesting_SameTarget(t *testing.T) {
 }
 
 func TestNesting_PreserveSymlinks(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%", "-mapping=ro:/dir1/dir2:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=ro:/:%ROOT%", "--mapping=ro:/dir1/dir2:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("file"), 0644, "file in root directory")

--- a/integration/options_test.go
+++ b/integration/options_test.go
@@ -70,7 +70,7 @@ func TestOptions_Allow(t *testing.T) {
 				}
 				defer os.RemoveAll(tempDir)
 
-				_, stderr, err := utils.RunAndWait(1, d.allowFlag, "-mapping=ro:/:/", tempDir)
+				_, stderr, err := utils.RunAndWait(1, d.allowFlag, "--mapping=ro:/:/", tempDir)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -84,7 +84,7 @@ func TestOptions_Allow(t *testing.T) {
 			if d.allowFlag != "" {
 				args = append(args, d.allowFlag)
 			}
-			args = append(args, "-mapping=ro:/:%ROOT%")
+			args = append(args, "--mapping=ro:/:%ROOT%")
 
 			state := utils.MountSetupWithUser(t, user, args...)
 			defer state.TearDown(t)

--- a/integration/profiling_test.go
+++ b/integration/profiling_test.go
@@ -34,7 +34,7 @@ var listenAddressRegex = regexp.MustCompile(`starting HTTP server on ([^:]+:\d+)
 
 func TestProfiling_Http(t *testing.T) {
 	stderr := new(bytes.Buffer)
-	state := utils.MountSetupWithOutputs(t, nil, stderr, "--listen_address=localhost:0", "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetupWithOutputs(t, nil, stderr, "--listen_address=localhost:0", "--mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	matches := listenAddressRegex.FindStringSubmatch(stderr.String())
@@ -83,7 +83,7 @@ func TestProfiling_FileProfiles(t *testing.T) {
 	}
 	for _, d := range testData {
 		t.Run(d.name, func(t *testing.T) {
-			state := utils.MountSetup(t, append(d.args, "-mapping=ro:/:%ROOT%")...)
+			state := utils.MountSetup(t, append(d.args, "--mapping=ro:/:%ROOT%")...)
 			// Explicitly stop sandboxfs (which is different to what most other tests do).  We need
 			// to do this here to cause the profiles to be written to disk.
 			state.TearDown(t)

--- a/integration/read_only_test.go
+++ b/integration/read_only_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestReadOnly_DirectoryStructure(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%", "-mapping=ro:/mappings/dir:%ROOT%/mappings/dir", "-mapping=ro:/mappings/scaffold/dir:%ROOT%/mappings/dir")
+	state := utils.MountSetup(t, "--mapping=ro:/:%ROOT%", "--mapping=ro:/mappings/dir:%ROOT%/mappings/dir", "--mapping=ro:/mappings/scaffold/dir:%ROOT%/mappings/dir")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("dir1"), 0755)
@@ -52,7 +52,7 @@ func TestReadOnly_DirectoryStructure(t *testing.T) {
 }
 
 func TestReadOnly_FileContents(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("file"), 0400, "foo")
@@ -72,7 +72,7 @@ func TestReadOnly_FileContents(t *testing.T) {
 }
 
 func TestReadOnly_ReplaceUnderlyingFile(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	externalFile := state.RootPath("foo")
@@ -104,7 +104,7 @@ func TestReadOnly_ReplaceUnderlyingFile(t *testing.T) {
 }
 
 func TestReadOnly_MoveUnderlyingDirectory(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("first/a"), 0755)
@@ -150,7 +150,7 @@ func TestReadOnly_TargetDoesNotExist(t *testing.T) {
 }
 
 func TestReadOnly_RepeatedReadDirsWhileDirIsOpen(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%", "-mapping=ro:/dir:%ROOT%/dir", "-mapping=ro:/scaffold/abc:%ROOT%/dir")
+	state := utils.MountSetup(t, "--mapping=ro:/:%ROOT%", "--mapping=ro:/dir:%ROOT%/dir", "--mapping=ro:/scaffold/abc:%ROOT%/dir")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("mapped-dir"), 0755)
@@ -193,7 +193,7 @@ func TestReadOnly_RepeatedReadDirsWhileDirIsOpen(t *testing.T) {
 }
 
 func TestReadOnly_Attributes(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("dir"), 0755)
@@ -283,7 +283,7 @@ func TestReadOnly_Access(t *testing.T) {
 	//
 	// Note also that we must mount with "allow=other" so that our unprivileged executions
 	// can access the file system.
-	state := utils.MountSetupWithUser(t, root, "-allow=other", "-mapping=ro:/:%ROOT%", "-mapping=ro:/scaffold/dir/foo:%ROOT%/foo")
+	state := utils.MountSetupWithUser(t, root, "--allow=other", "--mapping=ro:/:%ROOT%", "--mapping=ro:/scaffold/dir/foo:%ROOT%/foo")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("all"), 0777) // Place where "user" can create entries.
@@ -356,7 +356,7 @@ func TestReadOnly_Access(t *testing.T) {
 }
 
 func TestReadOnly_HardLinkCountsAreFixed(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=ro:/:%ROOT%", "-mapping=ro:/scaffold/dir:%ROOT%/dir")
+	state := utils.MountSetup(t, "--mapping=ro:/:%ROOT%", "--mapping=ro:/scaffold/dir:%ROOT%/dir")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("dir"), 0755)

--- a/integration/read_write_test.go
+++ b/integration/read_write_test.go
@@ -49,7 +49,7 @@ func openAndDelete(path string, mode int) (int, error) {
 }
 
 func TestReadWrite_CreateFile(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("file"), 0644, "original content")
@@ -65,7 +65,7 @@ func TestReadWrite_CreateFile(t *testing.T) {
 }
 
 func TestReadWrite_Remove(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%", "-mapping=rw:/mapped-dir:%ROOT%/mapped-dir", "-mapping=rw:/scaffold/dir:%ROOT%/scaffold-dir")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%", "--mapping=rw:/mapped-dir:%ROOT%/mapped-dir", "--mapping=rw:/scaffold/dir:%ROOT%/scaffold-dir")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("dir"), 0755)
@@ -120,7 +120,7 @@ func TestReadWrite_Remove(t *testing.T) {
 }
 
 func TestReadWrite_RewriteFile(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("file"), 0644, "original content")
@@ -135,7 +135,7 @@ func TestReadWrite_RewriteFile(t *testing.T) {
 }
 
 func TestReadWrite_RewriteFileWithShorterContent(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.MountPath("file"), 0644, "very long contents")
@@ -146,7 +146,7 @@ func TestReadWrite_RewriteFileWithShorterContent(t *testing.T) {
 }
 
 func TestReadWrite_InodeReassignedAfterRecreation(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	path := state.MountPath("file")
@@ -182,7 +182,7 @@ func TestReadWrite_InodeReassignedAfterRecreation(t *testing.T) {
 }
 
 func TestReadWrite_FstatOnDeletedNode(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.MountPath("dir"), 0755)
@@ -228,7 +228,7 @@ func TestReadWrite_FstatOnDeletedNode(t *testing.T) {
 }
 
 func TestReadWrite_Truncate(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.MountPath("file"), 0644, "very long contents")
@@ -244,7 +244,7 @@ func TestReadWrite_Truncate(t *testing.T) {
 }
 
 func TestReadWrite_FtruncateOnDeletedFile(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	originalContent := "very long contents"
@@ -346,8 +346,8 @@ func TestReadWrite_NestedMappingsInheritDirectoryProperties(t *testing.T) {
 		return os.MkdirAll(filepath.Join(root, "dir"), 0755)
 	}
 	state := utils.MountSetupWithRootSetup(t, rootSetup,
-		"-mapping=rw:/:%ROOT%",
-		"-mapping=ro:/already/exist/dir:%ROOT%/dir")
+		"--mapping=rw:/:%ROOT%",
+		"--mapping=ro:/already/exist/dir:%ROOT%/dir")
 	defer state.TearDown(t)
 
 	for _, path := range []string{"already/foo", "already/exist/foo"} {
@@ -375,9 +375,9 @@ func TestReadWrite_NestedMappingsClobberFiles(t *testing.T) {
 		return os.Symlink("/non-existent", filepath.Join(root, "symlink"))
 	}
 	state := utils.MountSetupWithRootSetup(t, rootSetup,
-		"-mapping=rw:/:%ROOT%",
-		"-mapping=ro:/file/nested-dir:%ROOT%/dir",
-		"-mapping=ro:/symlink/nested-dir:%ROOT%/dir")
+		"--mapping=rw:/:%ROOT%",
+		"--mapping=ro:/file/nested-dir:%ROOT%/dir",
+		"--mapping=ro:/symlink/nested-dir:%ROOT%/dir")
 	defer state.TearDown(t)
 
 	for _, component := range []string{"file", "symlink"} {
@@ -396,7 +396,7 @@ func TestReadWrite_NestedMappingsClobberFiles(t *testing.T) {
 }
 
 func TestReadWrite_RenameFile(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	oldOuterPath := state.RootPath("old-name")
@@ -407,7 +407,7 @@ func TestReadWrite_RenameFile(t *testing.T) {
 }
 
 func TestReadWrite_MoveFile(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	oldOuterPath := state.RootPath("dir1/dir2/old-name")
@@ -420,7 +420,7 @@ func TestReadWrite_MoveFile(t *testing.T) {
 func TestReadWrite_Mknod(t *testing.T) {
 	utils.RequireRoot(t, "Requires root privileges to create arbitrary nodes")
 
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	// checkNode ensures that a given file is of the specified type and, if the type indicates
@@ -522,7 +522,7 @@ func TestReadWrite_Mknod(t *testing.T) {
 }
 
 func TestReadWrite_Chmod(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	// checkPerm ensures that the given file has the given permissions on the underlying file
@@ -598,7 +598,7 @@ func TestReadWrite_Chmod(t *testing.T) {
 }
 
 func TestReadWrite_FchmodOnDeletedNode(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.MountPath("dir"), 0755)
@@ -639,7 +639,7 @@ func TestReadWrite_FchmodOnDeletedNode(t *testing.T) {
 func TestReadWrite_Chown(t *testing.T) {
 	utils.RequireRoot(t, "Requires root privileges to change test file ownership")
 
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	// checkOwners ensures that the given file is owned by the given user and group on the
@@ -706,7 +706,7 @@ func TestReadWrite_Chown(t *testing.T) {
 func TestReadWrite_FchownOnDeletedNode(t *testing.T) {
 	utils.RequireRoot(t, "Requires root privileges to change test file ownership")
 
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.MountPath("dir"), 0755)
@@ -745,7 +745,7 @@ func TestReadWrite_FchownOnDeletedNode(t *testing.T) {
 }
 
 func TestReadWrite_Chtimes(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	// checkTimes ensures that the given file has the desired timing information on the
@@ -855,7 +855,7 @@ func TestReadWrite_Chtimes(t *testing.T) {
 }
 
 func TestReadWrite_FutimesOnDeletedNode(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.MountPath("dir"), 0755)
@@ -901,7 +901,7 @@ func TestReadWrite_FutimesOnDeletedNode(t *testing.T) {
 }
 
 func TestReadWrite_HardLinksNotSupported(t *testing.T) {
-	state := utils.MountSetup(t, "-mapping=rw:/:%ROOT%", "-mapping=rw:/dir:%ROOT%/dir", "-mapping=rw:/scaffold/name3:%ROOT%/dir2")
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%", "--mapping=rw:/dir:%ROOT%/dir", "--mapping=rw:/scaffold/name3:%ROOT%/dir2")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.RootPath("name1"), 0644, "")

--- a/integration/reconfiguration_test.go
+++ b/integration/reconfiguration_test.go
@@ -106,7 +106,7 @@ func TestReconfiguration_Streams(t *testing.T) {
 			t.Fatalf("Failed to create %s fifo: %v", outFifo, err)
 		}
 
-		state := utils.MountSetupWithOutputs(t, nil, os.Stderr, "-input="+inFifo, "-output="+outFifo)
+		state := utils.MountSetupWithOutputs(t, nil, os.Stderr, "--input="+inFifo, "--output="+outFifo)
 		defer state.TearDown(t)
 
 		input, err := os.OpenFile(inFifo, os.O_WRONLY, 0)
@@ -131,7 +131,7 @@ func TestReconfiguration_Steps(t *testing.T) {
 	defer stdoutWriter.Close() // Just in case the test fails half-way through.
 	output := bufio.NewScanner(stdoutReader)
 
-	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "-mapping=ro:/:%ROOT%", "-mapping=rw:/initial:%ROOT%/initial")
+	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "--mapping=ro:/:%ROOT%", "--mapping=rw:/initial:%ROOT%/initial")
 	defer state.TearDown(t)
 
 	utils.MustMkdirAll(t, state.RootPath("some/read-only-dir"), 0755)
@@ -192,7 +192,7 @@ func TestReconfiguration_Unmap(t *testing.T) {
 	defer stdoutWriter.Close() // Just in case the test fails half-way through.
 	output := bufio.NewScanner(stdoutReader)
 
-	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "-mapping=ro:/:%ROOT%", "-mapping=ro:/root-mapping:%ROOT%/foo", "-mapping=ro:/nested/mapping:%ROOT%/foo", "-mapping=ro:/deep/a/b/c/d:%ROOT%/foo")
+	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "--mapping=ro:/:%ROOT%", "--mapping=ro:/root-mapping:%ROOT%/foo", "--mapping=ro:/nested/mapping:%ROOT%/foo", "--mapping=ro:/deep/a/b/c/d:%ROOT%/foo")
 	defer state.TearDown(t)
 
 	config := `[
@@ -229,7 +229,7 @@ func TestReconfiguration_RemapInvalidatesCache(t *testing.T) {
 	defer stdoutWriter.Close() // Just in case the test fails half-way through.
 	output := bufio.NewScanner(stdoutReader)
 
-	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "-mapping=ro:/:%ROOT%")
+	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "--mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
 
 	checkMountPoint := func(wantExist string, wantNotExist string, wantFileContents string, wantLink string) {
@@ -306,7 +306,7 @@ func TestReconfiguration_Errors(t *testing.T) {
 	defer stdoutWriter.Close() // Just in case the test fails half-way through.
 	output := bufio.NewScanner(stdoutReader)
 
-	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	checkBadConfig := func(config string, wantError string) {
@@ -428,7 +428,7 @@ func TestReconfiguration_RaceSystemComponents(t *testing.T) {
 		defer stdoutWriter.Close()
 		output := bufio.NewScanner(stdoutReader)
 
-		state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "-mapping=ro:/:%ROOT%")
+		state := utils.MountSetupWithOutputs(t, stdoutWriter, os.Stderr, "--mapping=ro:/:%ROOT%")
 		// state.TearDown not deferred here because we want to explicitly control for any
 		// possible error it may report and abort the whole test early in that case.
 

--- a/integration/signal_test.go
+++ b/integration/signal_test.go
@@ -74,7 +74,7 @@ func TestSignal_UnmountWhenCaught(t *testing.T) {
 		t.Run(signal.String(), func(t *testing.T) {
 			stderr := new(bytes.Buffer)
 
-			state := utils.MountSetupWithOutputs(t, nil, stderr, "-mapping=ro:/:%ROOT%")
+			state := utils.MountSetupWithOutputs(t, nil, stderr, "--mapping=ro:/:%ROOT%")
 			defer state.TearDown(t)
 
 			utils.MustWriteFile(t, state.RootPath("a"), 0644, "")
@@ -105,7 +105,7 @@ func TestSignal_QueuedWhileInUse(t *testing.T) {
 	defer stderrWriter.Close()
 	stderr := bufio.NewScanner(stderrReader)
 
-	state := utils.MountSetupWithOutputs(t, nil, stderrWriter, "-mapping=rw:/:%ROOT%")
+	state := utils.MountSetupWithOutputs(t, nil, stderrWriter, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
 
 	// Create a file under the root directory and open it via the mount point to keep the file

--- a/integration/utils/exec.go
+++ b/integration/utils/exec.go
@@ -215,7 +215,7 @@ func (s *MountState) TempPath(arg ...string) string {
 // the targetes of the mappings, and creates those paths.
 func createDirsRequiredByMappings(root string, args ...string) error {
 	for _, arg := range args {
-		if !strings.HasPrefix(arg, "-mapping=") {
+		if !strings.HasPrefix(arg, "--mapping=") {
 			continue // Not a mapping.
 		}
 		fields := strings.Split(arg, ":")
@@ -239,7 +239,7 @@ func createDirsRequiredByMappings(root string, args ...string) error {
 // mapping for the sandbox's root directory.
 func hasRootMapping(args ...string) bool {
 	for _, arg := range args {
-		if strings.HasPrefix(arg, "-mapping=ro:/:") || strings.HasPrefix(arg, "-mapping=rw:/:") {
+		if strings.HasPrefix(arg, "--mapping=ro:/:") || strings.HasPrefix(arg, "--mapping=rw:/:") {
 			return true
 		}
 	}


### PR DESCRIPTION
This is for consistency.  Go's flag library accepts flags to be specified
with a single or double dash, and we were mixing both syntaxes.