### PR TITLE
Fix linter to skip explicitly-specified blacklisted files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 .*.rej
 .*.swp
 .*~
-/bazel-*
 /.gopath
 /.gopath-tools
+/bazel-*

--- a/admin/pre-commit
+++ b/admin/pre-commit
@@ -22,5 +22,5 @@ index_files="$(git status --porcelain --untracked-files=no \
 
 if [ -n "${index_files}" ]; then
   echo "Linting changed files..."
-  bazel run //admin/lint -- ${index_files} || exit 1
+  bazel run //admin/lint -- --verbose ${index_files} || exit 1
 fi


### PR DESCRIPTION
The previous lint code would choke when asked to lint a blacklisted file
such as .gitignore on the command line, which happened from within the
pre-commit hook.

Fix this by generalizing the blacklist computation and applying it to
both auto-discovered files and explicitly-specified files.