### PR TITLE
Add skeleton reimplementation of sandboxfs in Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.gopath
 /.gopath-tools
 /bazel-*
+Cargo.lock
+target

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
   - DO=bazel
   - DO=gotools
   - DO=lint
+  - DO=rust
 
 before_install: ./admin/travis-install.sh
 script: ./admin/travis-build.sh
@@ -51,3 +52,8 @@ matrix:
       go: 1.8
     - env: DO=lint
       os: osx
+
+    # For testing the Rust implementation, we only need to build the tests using
+    # one Go version.
+    - env: DO=rust
+      go: 1.8

--- a/.vscode/settings.json.in
+++ b/.vscode/settings.json.in
@@ -41,6 +41,11 @@
     "editor.quickSuggestions": false
   },
 
+  "[rust]": {
+    "editor.rulers": [100],
+    "editor.wordWrapColumn": 100
+  },
+
   "[troff]": {
     "editor.quickSuggestions": false
   }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+authors = ["Julio Merino <jmmv@google.com>"]
+categories = ["filesystems"]
+description = "A virtual file system for sandboxing"
+homepage = "https://github.com/bazelbuild/sandboxfs"
+keywords = ["bazel", "filesystem", "fuse", "sandboxing"]
+license = "Apache-2.0"
+name = "sandboxfs"
+readme = "README.md"
+repository = "https://github.com/bazelbuild/sandboxfs"
+version = "0.1.0"
+
+[badges]
+travis-ci = { repository = "bazelbuild/sandboxfs", branch = "master" }
+
+[dependencies]
+fuse = "0.3"
+getopts = "0.2"
+log = "0.4"
+env_logger = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ version = "0.1.0"
 travis-ci = { repository = "bazelbuild/sandboxfs", branch = "master" }
 
 [dependencies]
+env_logger = "0.5"
+failure = "0.1"
 fuse = "0.3"
 getopts = "0.2"
 log = "0.4"
-env_logger = "0.5"

--- a/admin/lint/lint.go
+++ b/admin/lint/lint.go
@@ -76,7 +76,16 @@ func isBlacklisted(workspaceDir string, candidate string) (bool, error) {
 	// Skip hidden files as we don't need to run checks on them.  (This is not strictly
 	// true, but it's simpler this way for now and the risk is low given that the hidden
 	// files we have are trivial.)
-	return strings.HasPrefix(relative, "."), nil
+	if strings.HasPrefix(relative, ".") {
+		return true, nil
+	}
+
+	// Skip the Rust build directory.
+	if strings.HasPrefix(candidate, "target/") {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // collectFiles scans the given directory recursively and returns the paths to all regular files

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -143,8 +143,8 @@ do_rust() {
     TestSignal_QueuedWhileInUse
   )
 
-  # TODO(jmmv): Replace by a Bazel-based build once the Rust rules are
-  # capable of doing so.
+  # TODO(https://github.com/bazelbuild/rules_rust/issues/2): Replace by a
+  # Bazel-based build once the Rust rules are capable of doing so.
   cargo build
   local bin="$(pwd)/target/debug/sandboxfs"
   cargo test --verbose
@@ -176,7 +176,6 @@ do_rust() {
   done
   set -x
 
-  [ "${#valid[@]}" -gt 0 ] || return 0  # Only run tests if any are valid.
   for t in "${valid[@]}"; do
     go test -v -timeout=600s -test.run="^${t}$" \
         github.com/bazelbuild/sandboxfs/integration \

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -176,6 +176,7 @@ do_rust() {
   done
   set -x
 
+  [ "${#valid[@]}" -gt 0 ] || return 0  # Only run tests if any are valid.
   for t in "${valid[@]}"; do
     go test -v -timeout=600s -test.run="^${t}$" \
         github.com/bazelbuild/sandboxfs/integration \

--- a/admin/travis-install.sh
+++ b/admin/travis-install.sh
@@ -57,6 +57,13 @@ install_fuse() {
   esac
 }
 
+install_rust() {
+  # We need to manually install Rust because we can only specify a single
+  # language in .travis.yml, and that language is Go for now.
+  curl https://sh.rustup.rs -sSf | sh -s -- -y
+  PATH="${HOME}/.cargo/bin:${PATH}"
+}
+
 case "${DO}" in
   bazel)
     install_bazel
@@ -69,5 +76,10 @@ case "${DO}" in
 
   lint)
     install_bazel
+    ;;
+
+  rust)
+    install_fuse
+    install_rust
     ;;
 esac

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ struct SandboxFS {
 impl SandboxFS {
     /// Creates a new `SandboxFS` instance.
     fn new() -> SandboxFS {
-      SandboxFS {}
+        SandboxFS {}
     }
 }
 
@@ -42,6 +42,5 @@ pub fn mount(mount_point: &Path) -> io::Result<()> {
     let fs = SandboxFS::new();
     info!("Mounting file system onto {:?}", mount_point);
     fuse::mount(fs, &mount_point, &options)
-        .map_err(|e| io::Error::new(
-            e.kind(), format!("mount on {:?} failed: {}", mount_point, e)))
+        .map_err(|e| io::Error::new(e.kind(), format!("mount on {:?} failed: {}", mount_point, e)))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,47 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+extern crate fuse;
+#[macro_use] extern crate log;
+
+use std::ffi::OsStr;
+use std::io;
+use std::path::Path;
+
+/// FUSE file system implementation of sandboxfs.
+struct SandboxFS {
+}
+
+impl SandboxFS {
+    /// Creates a new `SandboxFS` instance.
+    fn new() -> SandboxFS {
+      SandboxFS {}
+    }
+}
+
+impl fuse::Filesystem for SandboxFS {
+}
+
+/// Mounts a new sandboxfs instance on the given `mount_point`.
+pub fn mount(mount_point: &Path) -> io::Result<()> {
+    let options = ["-o", "ro", "-o", "fsname=sandboxfs"]
+        .iter()
+        .map(|o| o.as_ref())
+        .collect::<Vec<&OsStr>>();
+    let fs = SandboxFS::new();
+    info!("Mounting file system onto {:?}", mount_point);
+    fuse::mount(fs, &mount_point, &options)
+        .map_err(|e| io::Error::new(
+            e.kind(), format!("mount on {:?} failed: {}", mount_point, e)))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,127 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+extern crate env_logger;
+extern crate getopts;
+extern crate sandboxfs;
+
+use getopts::Options;
+use std::env;
+use std::ffi::OsStr;
+use std::io;
+use std::path::Path;
+use std::process;
+use std::result::Result;
+
+/// Error-like type to encapsulate various different error conditions in the
+/// main program.
+#[derive(Debug)]
+enum MainError {
+    /// Execution failed due to a generic runtime error.
+    Runtime(String),
+    /// Execution failed due to a user-triggered error.
+    Usage(String),
+}
+
+impl From<io::Error> for MainError {
+    fn from(err: io::Error) -> Self {
+        MainError::Runtime(format!("{}", err))
+    }
+}
+
+impl From<getopts::Fail> for MainError {
+    fn from(err: getopts::Fail) -> Self {
+        MainError::Usage(format!("{}", err))
+    }
+}
+
+/// Obtains the program name from the execution's first argument, or returns a
+/// default if the program name cannot be determined for whatever reason.
+fn program_name(args: &[String], default: &'static str) -> String {
+    args.get(0)
+        .as_ref()
+        .map(Path::new)
+        .and_then(Path::file_name)
+        .and_then(OsStr::to_str)
+        .map(String::from)
+        .unwrap_or(default.to_string())
+}
+
+/// Prints program usage information to stdout.
+fn usage(program: &str, opts: &Options) {
+    let brief = format!("Usage: {} [options] MOUNT_POINT", program);
+    print!("{}", opts.usage(&brief));
+}
+
+/// Program's entry point.  This is a "safe" version of `main` in the sense that
+/// this doesn't directly handle errors: all errors are returned to the caller
+/// for consistent reporter to the user depending on their type.
+fn safe_main(program: &str, args: &[String]) -> Result<(), MainError> {
+    env_logger::init();
+
+    let mut opts = Options::new();
+    opts.optflag("", "help", "prints usage information and exits");
+    let matches = opts.parse(args)?;
+
+    if matches.opt_present("help") {
+        usage(&program, &opts);
+        return Ok(());
+    }
+
+    let mount_point = if matches.free.len() == 1 {
+        &matches.free[0]
+    } else {
+        return Err(MainError::Usage("invalid number of arguments".to_string()));
+    };
+
+    sandboxfs::mount(Path::new(mount_point))?;
+    Ok(())
+}
+
+/// Program's entry point.  This delegates to `safe_main` for all program logic
+/// and is just in charge of consistently formatting and reporting all possible
+/// errors to the caller.
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let program = program_name(&args, "sandboxfs");
+
+    match safe_main(&program, &args[1..]) {
+        Ok(_) => (),
+        Err(MainError::Runtime(message)) => {
+            eprintln!("{}: {}", program, message);
+            process::exit(1);
+        },
+        Err(MainError::Usage(message)) => {
+            eprintln!("Usage error: {}", message);
+            eprintln!("Type {} --help for more information", program);
+            process::exit(2);
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_program_name_uses_default_on_errors() {
+        assert_eq!("default", program_name(&[], "default"));
+    }
+
+    #[test]
+    fn test_program_name_uses_file_name_only() {
+        assert_eq!("b", program_name(&["a/b".to_string()], "unused"));
+        assert_eq!("foo", program_name(&["./x/y/foo".to_string()], "unused"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,13 +49,17 @@ impl From<getopts::Fail> for MainError {
 /// Obtains the program name from the execution's first argument, or returns a
 /// default if the program name cannot be determined for whatever reason.
 fn program_name(args: &[String], default: &'static str) -> String {
-    args.get(0)
-        .as_ref()
-        .map(Path::new)
-        .and_then(Path::file_name)
-        .and_then(OsStr::to_str)
-        .map(String::from)
-        .unwrap_or(default.to_string())
+    let default = String::from(default);
+    match args.get(0) {
+        Some(arg0) => match Path::new(arg0).file_name() {
+            Some(basename) => match basename.to_str() {
+                Some(basename) => String::from(basename),
+                None => default,
+            },
+            None => default,
+        },
+        None => default,
+    }
 }
 
 /// Prints program usage information to stdout.

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,11 +88,11 @@ fn main() {
     let program = program_name(&args, "sandboxfs");
 
     if let Err(err) = safe_main(&program, &args[1..]) {
-        if let Some(err) = err.cause().downcast_ref::<UsageError>() {
+        if let Some(err) = err.downcast_ref::<UsageError>() {
             eprintln!("Usage error: {}", err);
             eprintln!("Type {} --help for more information", program);
             process::exit(2);
-        } else if let Some(err) = err.cause().downcast_ref::<getopts::Fail>() {
+        } else if let Some(err) = err.downcast_ref::<getopts::Fail>() {
             eprintln!("Usage error: {}", err);
             eprintln!("Type {} --help for more information", program);
             process::exit(2);

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,8 @@ struct UsageError {
     message: String,
 }
 
-/// Obtains the program name from the execution's first argument, or returns a
-/// default if the program name cannot be determined for whatever reason.
+/// Obtains the program name from the execution's first argument, or returns a default if the
+/// program name cannot be determined for whatever reason.
 fn program_name(args: &[String], default: &'static str) -> String {
     let default = String::from(default);
     match args.get(0) {
@@ -53,9 +53,9 @@ fn usage(program: &str, opts: &Options) {
     print!("{}", opts.usage(&brief));
 }
 
-/// Program's entry point.  This is a "safe" version of `main` in the sense that
-/// this doesn't directly handle errors: all errors are returned to the caller
-/// for consistent reporter to the user depending on their type.
+/// Program's entry point.  This is a "safe" version of `main` in the sense that this doesn't
+/// directly handle errors: all errors are returned to the caller for consistent reporter to the
+/// user depending on their type.
 fn safe_main(program: &str, args: &[String]) -> Result<(), Error> {
     env_logger::init();
 
@@ -71,18 +71,15 @@ fn safe_main(program: &str, args: &[String]) -> Result<(), Error> {
     let mount_point = if matches.free.len() == 1 {
         &matches.free[0]
     } else {
-        return Err(Error::from(UsageError {
-            message: "invalid number of arguments".to_string(),
-        }));
+        return Err(Error::from(UsageError { message: "invalid number of arguments".to_string() }));
     };
 
     sandboxfs::mount(Path::new(mount_point))?;
     Ok(())
 }
 
-/// Program's entry point.  This delegates to `safe_main` for all program logic
-/// and is just in charge of consistently formatting and reporting all possible
-/// errors to the caller.
+/// Program's entry point.  This delegates to `safe_main` for all program logic and is just in
+/// charge of consistently formatting and reporting all possible errors to the caller.
 fn main() {
     let args: Vec<String> = env::args().collect();
     let program = program_name(&args, "sandboxfs");


### PR DESCRIPTION
This change adds a barebones reimplementation of sandboxfs in Rust.
As things are now, the new version does nothing: it just provides
trivial command-line processing and mounts an empty FUSE file
system.

However, this change puts all pieces in place to continue development
of this new version.  In particular, this adjusts the Travis CI
configuration to support running the exact same integration tests as
we run for the Go implementation against the new code, and currently
blacklists all of them because the new code passes none.