### PR TITLE
Fix Mac builds on Travis and upgrade to Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,14 @@ os:
   - linux
   - osx
 
+# Pin to macOS 10.12 (indirectly by using the Xcode 8.3 image).  We must do
+# this to get the OSXFUSE kernel extension to work because there currently
+# is no know way to programmatically grant permissions to load a kernel
+# extension in macOS 10.13.
+#
+# See https://github.com/travis-ci/travis-ci/issues/10017 for details.
+osx_image: xcode8.3
+
 language:
   - go  # For ourselves.
   - java  # For Bazel.

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,9 @@ language:
   - java  # For Bazel.
 
 go:
-  - 1.8
-  - 1.9
+  - "1.8"
+  - "1.9"
+  - "1.10"
 go_import_path: github.com/bazelbuild/sandboxfs
 
 env:
@@ -38,22 +39,30 @@ script: ./admin/travis-build.sh
 
 matrix:
   exclude:
-    # For Go 1.8, we are only interested in testing that our code builds
+    # For Go 1.8 and 1.9, we are only interested in testing that our code builds
     # correctly under that version of the language.  A single test is sufficient
     # for this, so remove all other configurations.
     - env: DO=gotools
-      go: 1.8
-    - go: 1.8
+      go: "1.8"
+    - env: DO=gotools
+      go: "1.9"
+    - go: "1.8"
+      os: osx
+    - go: "1.9"
       os: osx
 
     # For code linting, we just need to run this under a single configuration.
     # Trim all but one, and prefer Linux over macOS because it's much faster.
     - env: DO=lint
-      go: 1.8
+      go: "1.8"
+    - env: DO=lint
+      go: "1.9"
     - env: DO=lint
       os: osx
 
     # For testing the Rust implementation, we only need to build the tests using
     # one Go version.
     - env: DO=rust
-      go: 1.8
+      go: "1.8"
+    - env: DO=rust
+      go: "1.9"


### PR DESCRIPTION
The two commits in this branch fix a couple of issues in the Travis configuration, making Mac builds work again and belatedly upgrading our environment to Go 1.10.