### PR TITLE
Implement parsing of mappings specified in flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,20 +53,16 @@ impl Mapping {
     ///
     /// `path` is the inside the sandbox's mount point where the `underlying_path` is exposed.
     /// Both must be absolute paths.
-    pub fn new(path: &Path, underlying_path: &Path, writable: bool)
+    pub fn new(path: PathBuf, underlying_path: PathBuf, writable: bool)
         -> Result<Mapping, PathNotAbsoluteError> {
         if !path.is_absolute() {
-            return Err(PathNotAbsoluteError { path: path.to_path_buf() });
+            return Err(PathNotAbsoluteError { path: path });
         }
         if !underlying_path.is_absolute() {
-            return Err(PathNotAbsoluteError { path: underlying_path.to_path_buf() });
+            return Err(PathNotAbsoluteError { path: underlying_path });
         }
 
-        Ok(Mapping {
-            path: PathBuf::from(path),
-            underlying_path: PathBuf::from(underlying_path),
-            writable,
-        })
+        Ok(Mapping { path, underlying_path, writable })
     }
 }
 
@@ -174,7 +170,7 @@ mod tests {
 
     #[test]
     fn test_mapping_new_ok() {
-        let mapping = Mapping::new(Path::new("/foo"), Path::new("/bar"), false).unwrap();
+        let mapping = Mapping::new(PathBuf::from("/foo"), PathBuf::from("/bar"), false).unwrap();
         assert_eq!(Path::new("/foo"), mapping.path);
         assert_eq!(Path::new("/bar"), mapping.underlying_path);
         assert!(!mapping.writable);
@@ -182,13 +178,13 @@ mod tests {
 
     #[test]
     fn test_mapping_new_bad_path() {
-        let err = Mapping::new(Path::new("foo"), Path::new("/bar"), false).unwrap_err();
+        let err = Mapping::new(PathBuf::from("foo"), PathBuf::from("/bar"), false).unwrap_err();
         assert_eq!(Path::new("foo"), err.path);
     }
 
     #[test]
     fn test_mapping_new_bad_underlying_path() {
-        let err = Mapping::new(Path::new("/foo"), Path::new("bar"), false).unwrap_err();
+        let err = Mapping::new(PathBuf::from("/foo"), PathBuf::from("bar"), false).unwrap_err();
         assert_eq!(Path::new("bar"), err.path);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ mod tests {
 
     #[test]
     fn test_parse_mappings_ok() {
-        let args = vec!("ro:/:/fake/root".to_string(), "rw:/foo:/bar".to_string());
+        let args = ["ro:/:/fake/root", "rw:/foo:/bar"];
         let exp_mappings = vec!(
             Mapping::new(Path::new("/"), Path::new("/fake/root"), false).unwrap(),
             Mapping::new(Path::new("/foo"), Path::new("/bar"), true).unwrap(),
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn test_parse_mappings_bad_format() {
         for arg in ["", "foo:bar", "foo:bar:baz:extra"].iter() {
-            let err = parse_mappings(&vec!(arg.to_string())).unwrap_err();
+            let err = parse_mappings(&[arg]).unwrap_err();
             assert_eq!(
                 format!("bad mapping {}: expected three colon-separated fields", arg),
                 format!("{}", err));
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn test_parse_mappings_bad_type() {
-        let args = vec!("rr:/foo:/bar".to_string());
+        let args = ["rr:/foo:/bar"];
         let err = parse_mappings(&args).unwrap_err();
         assert_eq!("bad mapping rr:/foo:/bar: type was rr but should be ro or rw",
             format!("{}", err));
@@ -183,14 +183,14 @@ mod tests {
 
     #[test]
     fn test_parse_mappings_bad_path() {
-        let args = vec!("ro:foo:/bar".to_string());
+        let args = ["ro:foo:/bar"];
         let err = parse_mappings(&args).unwrap_err();
         assert_eq!("bad mapping ro:foo:/bar: path \"foo\" is not absolute", format!("{}", err));
     }
 
     #[test]
     fn test_parse_mappings_bad_underlying_path() {
-        let args = vec!("ro:/foo:bar".to_string());
+        let args = ["ro:/foo:bar"];
         let err = parse_mappings(&args).unwrap_err();
         assert_eq!("bad mapping ro:/foo:bar: path \"bar\" is not absolute", format!("{}", err));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ extern crate sandboxfs;
 use failure::Error;
 use getopts::Options;
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::result::Result;
 
@@ -58,8 +58,8 @@ fn parse_mappings<T: AsRef<str>, U: IntoIterator<Item=T>>(args: U)
             }
         };
 
-        let path = Path::new(fields[1]);
-        let underlying_path = Path::new(fields[2]);
+        let path = PathBuf::from(fields[1]);
+        let underlying_path = PathBuf::from(fields[2]);
 
         match sandboxfs::Mapping::new(path, underlying_path, writable) {
             Ok(mapping) => mappings.push(mapping),
@@ -154,8 +154,8 @@ mod tests {
     fn test_parse_mappings_ok() {
         let args = ["ro:/:/fake/root", "rw:/foo:/bar"];
         let exp_mappings = vec!(
-            Mapping::new(Path::new("/"), Path::new("/fake/root"), false).unwrap(),
-            Mapping::new(Path::new("/foo"), Path::new("/bar"), true).unwrap(),
+            Mapping::new(PathBuf::from("/"), PathBuf::from("/fake/root"), false).unwrap(),
+            Mapping::new(PathBuf::from("/foo"), PathBuf::from("/bar"), true).unwrap(),
         );
         match parse_mappings(&args) {
             Ok(mappings) => assert_eq!(exp_mappings, mappings),

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,9 @@ fn parse_mappings<T: AsRef<str>, U: IntoIterator<Item=T>>(args: U)
         match sandboxfs::Mapping::new(path, underlying_path, writable) {
             Ok(mapping) => mappings.push(mapping),
             Err(e) => {
+                // TODO(jmmv): Figure how to best leverage failure's cause propagation.  May need
+                // to define a custom ErrorKind to represent UsageError, instead of having a special
+                // error type.
                 let message = format!("bad mapping {}: {}", arg, e);
                 return Err(UsageError { message });
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,10 +33,13 @@ struct UsageError {
 
 /// Takes the list of strings that represent mappings (supplied via multiple instances of the
 /// `--mapping` flag) and returns a parsed representation of those flags.
-fn parse_mappings(args: &Vec<String>) -> Result<Vec<sandboxfs::Mapping>, UsageError> {
+fn parse_mappings<T: AsRef<str>, U: IntoIterator<Item=T>>(args: U)
+    -> Result<Vec<sandboxfs::Mapping>, UsageError> {
     let mut mappings = Vec::new();
 
     for arg in args {
+        let arg = arg.as_ref();
+
         let fields: Vec<&str> = arg.split(":").collect();
         if fields.len() != 3 {
             let message = format!("bad mapping {}: expected three colon-separated fields", arg);
@@ -108,7 +111,7 @@ fn safe_main(program: &str, args: &[String]) -> Result<(), Error> {
         return Ok(());
     }
 
-    let mappings = parse_mappings(&matches.opt_strs("mapping"))?;
+    let mappings = parse_mappings(matches.opt_strs("mapping").into_iter())?;
 
     let mount_point = if matches.free.len() == 1 {
         &matches.free[0]

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ fn safe_main(program: &str, args: &[String]) -> Result<(), Error> {
         return Ok(());
     }
 
-    let mappings = parse_mappings(matches.opt_strs("mapping").into_iter())?;
+    let mappings = parse_mappings(matches.opt_strs("mapping"))?;
 
     let mount_point = if matches.free.len() == 1 {
         &matches.free[0]

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,45 @@ struct UsageError {
     message: String,
 }
 
+/// Takes the list of strings that represent mappings (supplied via multiple instances of the
+/// `--mapping` flag) and returns a parsed representation of those flags.
+fn parse_mappings(args: &Vec<String>) -> Result<Vec<sandboxfs::Mapping>, UsageError> {
+    let mut mappings = Vec::new();
+
+    for arg in args {
+        let fields: Vec<&str> = arg.split(":").collect();
+        if fields.len() != 3 {
+            let message = format!("bad mapping {}: expected three colon-separated fields", arg);
+            return Err(UsageError { message });
+        }
+
+        let writable = {
+            if fields[0] == "ro" {
+                false
+            } else if fields[0] == "rw" {
+                true
+            } else {
+                let message = format!("bad mapping {}: type was {} but should be ro or rw",
+                    arg, fields[0]);
+                return Err(UsageError { message });
+            }
+        };
+
+        let path = Path::new(fields[1]);
+        let underlying_path = Path::new(fields[2]);
+
+        match sandboxfs::Mapping::new(path, underlying_path, writable) {
+            Ok(mapping) => mappings.push(mapping),
+            Err(e) => {
+                let message = format!("bad mapping {}: {}", arg, e);
+                return Err(UsageError { message });
+            }
+        }
+    }
+
+    Ok(mappings)
+}
+
 /// Obtains the program name from the execution's first argument, or returns a default if the
 /// program name cannot be determined for whatever reason.
 fn program_name(args: &[String], default: &'static str) -> String {
@@ -61,6 +100,7 @@ fn safe_main(program: &str, args: &[String]) -> Result<(), Error> {
 
     let mut opts = Options::new();
     opts.optflag("", "help", "prints usage information and exits");
+    opts.optmulti("", "mapping", "type and locations of a mapping", "TYPE:PATH:UNDERLYING_PATH");
     let matches = opts.parse(args)?;
 
     if matches.opt_present("help") {
@@ -68,13 +108,15 @@ fn safe_main(program: &str, args: &[String]) -> Result<(), Error> {
         return Ok(());
     }
 
+    let mappings = parse_mappings(&matches.opt_strs("mapping"))?;
+
     let mount_point = if matches.free.len() == 1 {
         &matches.free[0]
     } else {
         return Err(Error::from(UsageError { message: "invalid number of arguments".to_string() }));
     };
 
-    sandboxfs::mount(Path::new(mount_point))?;
+    sandboxfs::mount(Path::new(mount_point), &mappings)?;
     Ok(())
 }
 
@@ -103,6 +145,52 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::sandboxfs::Mapping;
+
+    #[test]
+    fn test_parse_mappings_ok() {
+        let args = vec!("ro:/:/fake/root".to_string(), "rw:/foo:/bar".to_string());
+        let exp_mappings = vec!(
+            Mapping::new(Path::new("/"), Path::new("/fake/root"), false).unwrap(),
+            Mapping::new(Path::new("/foo"), Path::new("/bar"), true).unwrap(),
+        );
+        match parse_mappings(&args) {
+            Ok(mappings) => assert_eq!(exp_mappings, mappings),
+            Err(e) => panic!(e),
+        }
+    }
+
+    #[test]
+    fn test_parse_mappings_bad_format() {
+        for arg in ["", "foo:bar", "foo:bar:baz:extra"].iter() {
+            let err = parse_mappings(&vec!(arg.to_string())).unwrap_err();
+            assert_eq!(
+                format!("bad mapping {}: expected three colon-separated fields", arg),
+                format!("{}", err));
+        }
+    }
+
+    #[test]
+    fn test_parse_mappings_bad_type() {
+        let args = vec!("rr:/foo:/bar".to_string());
+        let err = parse_mappings(&args).unwrap_err();
+        assert_eq!("bad mapping rr:/foo:/bar: type was rr but should be ro or rw",
+            format!("{}", err));
+    }
+
+    #[test]
+    fn test_parse_mappings_bad_path() {
+        let args = vec!("ro:foo:/bar".to_string());
+        let err = parse_mappings(&args).unwrap_err();
+        assert_eq!("bad mapping ro:foo:/bar: path \"foo\" is not absolute", format!("{}", err));
+    }
+
+    #[test]
+    fn test_parse_mappings_bad_underlying_path() {
+        let args = vec!("ro:/foo:bar".to_string());
+        let err = parse_mappings(&args).unwrap_err();
+        assert_eq!("bad mapping ro:/foo:bar: path \"bar\" is not absolute", format!("{}", err));
+    }
 
     #[test]
     fn test_program_name_uses_default_on_errors() {


### PR DESCRIPTION
This change adds support for a repeated --mapping flag.  Each instance
of this flag represents a path entry to map within the sandbox.

Note, however, that this only adds the flag but that the value of the
flag is currently unused.  This is a prerequisite for implementing
support for a mapped root directory, which will come next.