### PR TITLE
Implement getattr on directories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ getopts = "0.2"
 libc = "0.2"
 log = "0.4"
 time = "0.1"
+
+[dev-dependencies]
+tempdir = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,9 @@ struct SandboxFS {
 
 impl SandboxFS {
     /// Creates a new `SandboxFS` instance.
-    fn new(mappings: &Vec<Mapping>) -> io::Result<SandboxFS> {
+    fn new(mappings: &[Mapping]) -> io::Result<SandboxFS> {
         let root = {
-            if mappings.len() == 0 {
+            if mappings.is_empty() {
                 let now = time::get_time();
                 let uid = unsafe { libc::getuid() } as u32;
                 let gid = unsafe { libc::getgid() } as u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,12 @@
 extern crate fuse;
 extern crate libc;
 #[macro_use] extern crate log;
+#[cfg(test)] extern crate tempdir;
 extern crate time;
 
 use std::collections::HashMap;
 use std::ffi::OsStr;
+use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::result::Result;
@@ -74,19 +76,36 @@ struct SandboxFS {
 
 impl SandboxFS {
     /// Creates a new `SandboxFS` instance.
-    fn new() -> SandboxFS {
+    fn new(mappings: &Vec<Mapping>) -> io::Result<SandboxFS> {
         let root = {
-            let now = time::get_time();
-            let uid = unsafe { libc::getuid() } as u32;
-            let gid = unsafe { libc::getgid() } as u32;
-            nodes::Dir::new_root(now, uid, gid)
+            if mappings.len() == 0 {
+                let now = time::get_time();
+                let uid = unsafe { libc::getuid() } as u32;
+                let gid = unsafe { libc::getgid() } as u32;
+                nodes::Dir::new_root(now, uid, gid)
+            } else if mappings.len() == 1 {
+                if mappings[0].path != Path::new("/") {
+                    panic!("Unimplemented; only support a single mapping for the root directory");
+                }
+                let fs_attr = fs::symlink_metadata(&mappings[0].underlying_path)?;
+                if !fs_attr.is_dir() {
+                    warn!("Path {:?} is not a directory; got {:?}", &mappings[0].underlying_path,
+                        &fs_attr);
+                    return Err(io::Error::from_raw_os_error(libc::EIO));
+                }
+                nodes::Dir::new_mapped(fuse::FUSE_ROOT_ID, &mappings[0].underlying_path, &fs_attr)
+            } else {
+                panic!("Unimplemented; only support zero or one mappings so far");
+            }
         };
 
         let mut nodes = HashMap::new();
+        assert_eq!(fuse::FUSE_ROOT_ID, root.inode());
         nodes.insert(root.inode(), root);
-        SandboxFS {
+
+        Ok(SandboxFS {
             nodes: Arc::from(Mutex::from(nodes)),
-        }
+        })
     }
 
     /// Gets a node given its `inode`.
@@ -154,11 +173,7 @@ pub fn mount(mount_point: &Path, mappings: &[Mapping]) -> io::Result<()> {
         .iter()
         .map(|o| o.as_ref())
         .collect::<Vec<&OsStr>>();
-
-    // TODO(jmmv): Handle the list of mappings by passing it into the file system.
-    let _mappings = mappings;
-
-    let fs = SandboxFS::new();
+    let fs = SandboxFS::new(mappings)?;
     info!("Mounting file system onto {:?}", mount_point);
     fuse::mount(fs, &mount_point, &options)
         .map_err(|e| io::Error::new(e.kind(), format!("mount on {:?} failed: {}", mount_point, e)))

--- a/src/nodes/conv.rs
+++ b/src/nodes/conv.rs
@@ -179,13 +179,6 @@ mod tests {
         assert_eq!(BAD_TIME, timespec);
     }
 
-    /// Sets the permissions of a file to exactly those given.
-    fn chmod(path: &Path, perm: libc::mode_t) {
-        let path = path.as_os_str().to_str().unwrap().as_bytes();
-        let path = CString::new(path).unwrap();
-        assert_eq!(0, unsafe { libc::chmod(path.as_ptr(), perm) });
-    }
-
     /// Creates a block or character device and enforces that it is created successfully.
     fn mkdev(path: &Path, type_mask: libc::mode_t, dev: libc::dev_t) {
         assert!(type_mask == libc::S_IFBLK || type_mask == libc::S_IFCHR);
@@ -307,7 +300,7 @@ mod tests {
         fs::create_dir(path.join("subdir1")).unwrap();
         fs::create_dir(path.join("subdir2")).unwrap();
 
-        chmod(&path, 0o750);
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o750)).unwrap();
         let atime = Timespec { sec: 12345, nsec: 0 };
         let mtime = Timespec { sec: 678, nsec: 0 };
         utimes(&path, &atime, &mtime);
@@ -347,7 +340,7 @@ mod tests {
         file.write_all(content.as_bytes()).unwrap();
         drop(file);
 
-        chmod(&path, 0o640);
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o640)).unwrap();
         let atime = Timespec { sec: 54321, nsec: 0 };
         let mtime = Timespec { sec: 876, nsec: 0 };
         utimes(&path, &atime, &mtime);

--- a/src/nodes/conv.rs
+++ b/src/nodes/conv.rs
@@ -215,7 +215,7 @@ mod tests {
         let path = dir.path().join("entry");
         create_entry(&path);
         let fs_type = fs::symlink_metadata(&path).unwrap().file_type();
-        assert_eq!(exp_type, filetype_fs_to_fuse(&path, &fs_type));
+        assert_eq!(exp_type, filetype_fs_to_fuse(&path, fs_type));
     }
 
     #[test]

--- a/src/nodes/conv.rs
+++ b/src/nodes/conv.rs
@@ -1,0 +1,384 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+use fuse;
+use libc;
+use std::fs;
+use std::io;
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+use time::Timespec;
+
+/// Fixed point in time to use when we fail to interpret file system supplied timestamps.
+const BAD_TIME: Timespec = Timespec { sec: 0, nsec: 0 };
+
+/// Converts a system time as represented in a fs::Metadata object to a Timespec.
+///
+/// `path` is the file from which the timestamp was originally extracted and `name` represents the
+/// metadata field the timestamp corresponds to; both are used for debugging purposes only.
+///
+/// If the given system time is missing, or if it is invalid, logs a warning and returns a fixed
+/// time.  It is reasonable for these details to be missing because the backing file systems do
+/// not always implement all possible file timestamps.
+fn system_time_to_timespec(path: &Path, name: &str, time: &io::Result<SystemTime>) -> Timespec {
+    match time {
+        Ok(time) => match time.duration_since(UNIX_EPOCH) {
+            Ok(duration) => Timespec::new(duration.as_secs() as i64,
+                                          duration.subsec_nanos() as i32),
+            Err(e) => {
+                warn!("File system returned {} {:?} for {:?} that's before the Unix epoch: {}",
+                      name, time, path, e);
+                BAD_TIME
+            }
+        },
+        Err(e) => {
+            warn!("File system did not return a {} timestamp for {:?}: {}", name, path, e);
+            BAD_TIME
+        },
+    }
+}
+
+/// Converts a file type as returned by the file system to a FUSE file type.
+///
+/// `path` is the file from which the file type was originally extracted and is only for debugging
+/// purposes.
+///
+/// If the given file type cannot be mapped to a FUSE file type (because we don't know about that
+/// type or, most likely, because the file type is bogus), logs a warning and returns a regular
+/// file type with the assumption that most operations should work on it.
+fn filetype_fs_to_fuse(path: &Path, fs_type: &fs::FileType) -> fuse::FileType {
+    if fs_type.is_block_device() {
+        fuse::FileType::BlockDevice
+    } else if fs_type.is_char_device() {
+        fuse::FileType::CharDevice
+    } else if fs_type.is_dir() {
+        fuse::FileType::Directory
+    } else if fs_type.is_fifo() {
+        fuse::FileType::NamedPipe
+    } else if fs_type.is_file() {
+        fuse::FileType::RegularFile
+    } else if fs_type.is_socket() {
+        fuse::FileType::Socket
+    } else if fs_type.is_symlink() {
+        fuse::FileType::Symlink
+    } else {
+        warn!("File system returned invalid file type {:?} for {:?}", fs_type, path);
+        fuse::FileType::RegularFile
+    }
+}
+
+/// Converts metadata attributes supplied by the file system to a FUSE file attributes tuple.
+///
+/// `inode` is the value of the FUSE inode (not the value of the inode supplied within `attr`) to
+/// fill into the returned file attributes.  `path` is the file from which the attributes were
+/// originally extracted and is only for debugging purposes.
+///
+/// Any errors encountered along the conversion process are logged and the corresponding field is
+/// replaced by a reasonable value that should work.  In other words: all errors are swallowed.
+pub fn attr_fs_to_fuse(path: &Path, inode: u64, attr: &fs::Metadata) -> fuse::FileAttr {
+    let nlink = if attr.is_dir() {
+        2  // "." entry plus whichever initial named node points at this.
+    } else {
+        1  // We don't support hard links so this is always valid.
+    };
+
+    let len = if attr.is_dir() {
+        2  // TODO(jmmv): Reevaluate what directory sizes should be.
+    } else {
+        attr.len()
+    };
+
+    // TODO(jmmv): Using the underlying ctimes is slightly wrong because the ctimes track changes
+    // to the inodes.  In most cases, operations that flow via sandboxfs will affect the underlying
+    // ctime and propagate through here, which is fine, but other operations are purely in-memory.
+    // To properly handle those cases, we should have our own ctime handling.
+    let ctime = Timespec { sec: attr.ctime(), nsec: attr.ctime_nsec() as i32 };
+
+    let perm = match attr.permissions().mode() {
+        // TODO(https://github.com/rust-lang/rust/issues/51577): Drop :: prefix.
+        mode if mode > ::std::u16::MAX as u32 => {
+            warn!("File system returned mode {} for {:?}, which is too large; set to 0400",
+                mode, path);
+            0o400
+        },
+        mode => (mode as u16) & !libc::S_IFMT,
+    };
+
+    let rdev = match attr.rdev() {
+        // TODO(https://github.com/rust-lang/rust/issues/51577): Drop :: prefix.
+        rdev if rdev > ::std::u32::MAX as u64 => {
+            warn!("File system returned rdev {} for {:?}, which is too large; set to 0",
+                rdev, path);
+            0
+        },
+        rdev => rdev as u32,
+    };
+
+    fuse::FileAttr {
+        ino: inode,
+        kind: filetype_fs_to_fuse(path, &attr.file_type()),
+        nlink: nlink,
+        size: len,
+        blocks: 0, // TODO(jmmv): Reevaluate what blocks should be.
+        atime: system_time_to_timespec(path, "atime", &attr.accessed()),
+        mtime: system_time_to_timespec(path, "mtime", &attr.modified()),
+        ctime: ctime,
+        crtime: system_time_to_timespec(path, "crtime", &attr.created()),
+        perm: perm,
+        uid: attr.uid(),
+        gid: attr.gid(),
+        rdev: rdev,
+        flags: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::ffi::CString;
+    use std::fs::File;
+    use std::io::Write;
+    use std::os::unix;
+    use std::time::Duration;
+    use tempdir::TempDir;
+
+    #[test]
+    fn test_system_time_to_timespec_ok() {
+        let sys_time = SystemTime::UNIX_EPOCH + Duration::new(12345, 6789);
+        let timespec = system_time_to_timespec(
+            &Path::new("irrelevant"), "irrelevant", &Ok(sys_time));
+        assert_eq!(Timespec { sec: 12345, nsec: 6789 }, timespec);
+    }
+
+    #[test]
+    fn test_system_time_to_timespec_bad() {
+        let sys_time = SystemTime::UNIX_EPOCH - Duration::new(1, 0);
+        let timespec = system_time_to_timespec(
+            &Path::new("irrelevant"), "irrelevant", &Ok(sys_time));
+        assert_eq!(BAD_TIME, timespec);
+    }
+
+    #[test]
+    fn test_system_time_to_timespec_missing() {
+        let timespec = system_time_to_timespec(
+            &Path::new("irrelevant"), "irrelevant",
+            &Err(io::Error::from_raw_os_error(libc::ENOENT)));
+        assert_eq!(BAD_TIME, timespec);
+    }
+
+    /// Sets the permissions of a file to exactly those given, bypassing the umask.
+    fn chmod_exactly(path: &Path, perm: libc::mode_t) {
+        let path = path.as_os_str().to_str().unwrap().as_bytes();
+        let path = CString::new(path).unwrap();
+        assert_eq!(0, unsafe {
+            let old_umask = libc::umask(0);
+            let ret = libc::chmod(path.as_ptr(), perm);
+            libc::umask(old_umask);
+            ret
+        });
+    }
+
+    /// Creates a block or character device and enforces that it is created successfully.
+    fn mkdev(path: &Path, type_mask: libc::mode_t, dev: libc::dev_t) {
+        assert!(type_mask == libc::S_IFBLK || type_mask == libc::S_IFCHR);
+        let path = path.as_os_str().to_str().unwrap().as_bytes();
+        let path = CString::new(path).unwrap();
+        assert_eq!(0, unsafe { libc::mknod(path.as_ptr(), 0o444 | type_mask, dev) });
+    }
+
+    /// Creates a named pipe and enforces that it is created successfully.
+    fn mkfifo(path: &Path) {
+        let path = path.as_os_str().to_str().unwrap().as_bytes();
+        let path = CString::new(path).unwrap();
+        assert_eq!(0, unsafe { libc::mkfifo(path.as_ptr(), 0o444) });
+    }
+
+    /// Sets the atime and mtime of a file to the given values.
+    fn utimes(path: &Path, atime: &Timespec, mtime: &Timespec) {
+        let times = [
+            libc::timeval { tv_sec: atime.sec, tv_usec: atime.nsec / 1000 },
+            libc::timeval { tv_sec: mtime.sec, tv_usec: mtime.nsec / 1000 },
+        ];
+        let path = path.as_os_str().to_str().unwrap().as_bytes();
+        let path = CString::new(path).unwrap();
+        assert_eq!(0, unsafe { libc::utimes(path.as_ptr(), &times[0]) });
+    }
+
+    /// Runs a test for `filetype_fs_to_fuse_test` for a single file type.
+    ///
+    /// `exp_type` is the expected return value of the function call, and `create_entry` is a
+    /// lambda that should create a file of the desired type in the path given to it.
+    fn do_filetype_fs_to_fuse_test<T: Fn(&Path) -> ()>(exp_type: fuse::FileType, create_entry: T) {
+        let dir = TempDir::new("test").unwrap();
+        let path = dir.path().join("entry");
+        create_entry(&path);
+        let fs_type = fs::symlink_metadata(&path).unwrap().file_type();
+        assert_eq!(exp_type, filetype_fs_to_fuse(&path, &fs_type));
+    }
+
+    #[test]
+    fn test_filetype_fs_to_fuse_blockdevice() {
+        let uid = unsafe { libc::getuid() } as u32;
+        if uid != 0 {
+            warn!("Not running as root; cannot create a block device");
+            return;
+        }
+
+        do_filetype_fs_to_fuse_test(
+            fuse::FileType::BlockDevice, |path| { mkdev(&path, libc::S_IFBLK, 50); });
+    }
+
+    #[test]
+    fn test_filetype_fs_to_fuse_chardevice() {
+        let uid = unsafe { libc::getuid() } as u32;
+        if uid != 0 {
+            warn!("Not running as root; cannot create a char device");
+            return;
+        }
+
+        do_filetype_fs_to_fuse_test(
+            fuse::FileType::CharDevice, |path| { mkdev(&path, libc::S_IFCHR, 50); });
+    }
+
+    #[test]
+    fn test_filetype_fs_to_fuse_directory() {
+        do_filetype_fs_to_fuse_test(
+            fuse::FileType::Directory, |path| { fs::create_dir(&path).unwrap(); });
+    }
+
+    #[test]
+    fn test_filetype_fs_to_fuse_namedpipe() {
+        do_filetype_fs_to_fuse_test(
+            fuse::FileType::NamedPipe, |path| { mkfifo(&path); });
+    }
+
+    #[test]
+    fn test_filetype_fs_to_fuse_regular() {
+        do_filetype_fs_to_fuse_test(
+            fuse::FileType::RegularFile, |path| { File::create(path).unwrap(); });
+    }
+
+    #[test]
+    fn test_filetype_fs_to_fuse_socket() {
+        do_filetype_fs_to_fuse_test(
+            fuse::FileType::Socket, |path| { unix::net::UnixListener::bind(&path).unwrap(); });
+    }
+
+    #[test]
+    fn test_filetype_fs_to_fuse_symlink() {
+        do_filetype_fs_to_fuse_test(
+            fuse::FileType::Symlink, |path| { unix::fs::symlink("irrelevant", &path).unwrap(); });
+    }
+
+    /// Asserts that two FUSE file attributes are equal.
+    ///
+    /// TODO(jmmv): Upstream an Eq implementation for fuse::Fileattr so that this becomes more
+    /// reliable and can provide nicer diagnostics on differences.
+    fn assert_fileattrs_eq(attr1: &fuse::FileAttr, attr2: &fuse::FileAttr) {
+        assert_eq!(attr1.ino, attr2.ino);
+        assert_eq!(attr1.kind, attr2.kind);
+        assert_eq!(attr1.nlink, attr2.nlink);
+        assert_eq!(attr1.size, attr2.size);
+        assert_eq!(attr1.blocks, attr2.blocks);
+        assert_eq!(attr1.atime, attr2.atime);
+        assert_eq!(attr1.mtime, attr2.mtime);
+        assert_eq!(attr1.ctime, attr2.ctime);
+        assert_eq!(attr1.crtime, attr2.crtime);
+        assert_eq!(attr1.perm, attr2.perm);
+        assert_eq!(attr1.uid, attr2.uid);
+        assert_eq!(attr1.gid, attr2.gid);
+        assert_eq!(attr1.rdev, attr2.rdev);
+        assert_eq!(attr1.flags, attr2.flags);
+    }
+
+    #[test]
+    fn test_attr_fs_to_fuse_directory() {
+        let dir = TempDir::new("test").unwrap();
+        let path = dir.path().join("root");
+        fs::create_dir(&path).unwrap();
+        fs::create_dir(path.join("subdir1")).unwrap();
+        fs::create_dir(path.join("subdir2")).unwrap();
+
+        chmod_exactly(&path, 0o750);
+        let atime = Timespec { sec: 12345, nsec: 0 };
+        let mtime = Timespec { sec: 678, nsec: 0 };
+        utimes(&path, &atime, &mtime);
+
+        let exp_attr = fuse::FileAttr {
+            ino: 1234,  // Ensure underlying inode is not propagated.
+            kind: fuse::FileType::Directory,
+            nlink: 2, // TODO(jmmv): Should account for subdirs.
+            size: 2,
+            blocks: 0,
+            atime: atime,
+            mtime: mtime,
+            ctime: BAD_TIME,
+            crtime: BAD_TIME,
+            perm: 0o750,
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+            rdev: 0,
+            flags: 0,
+        };
+
+        let mut attr = attr_fs_to_fuse(&path, 1234, &fs::symlink_metadata(&path).unwrap());
+        // We cannot really make any useful assertions on ctime and crtime as these cannot be
+        // modified and may not be queryable, so stub them out.
+        attr.ctime = BAD_TIME;
+        attr.crtime = BAD_TIME;
+        assert_fileattrs_eq(&exp_attr, &attr);
+    }
+
+    #[test]
+    fn test_attr_fs_to_fuse_regular() {
+        let dir = TempDir::new("test").unwrap();
+        let path = dir.path().join("file");
+
+        let mut file = File::create(&path).unwrap();
+        let content = "Some text\n";
+        file.write_all(content.as_bytes()).unwrap();
+        drop(file);
+
+        chmod_exactly(&path, 0o640);
+        let atime = Timespec { sec: 54321, nsec: 0 };
+        let mtime = Timespec { sec: 876, nsec: 0 };
+        utimes(&path, &atime, &mtime);
+
+        let exp_attr = fuse::FileAttr {
+            ino: 42,  // Ensure underlying inode is not propagated.
+            kind: fuse::FileType::RegularFile,
+            nlink: 1,
+            size: content.len() as u64,
+            blocks: 0,
+            atime: atime,
+            mtime: mtime,
+            ctime: BAD_TIME,
+            crtime: BAD_TIME,
+            perm: 0o640,
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+            rdev: 0,
+            flags: 0,
+        };
+
+        let mut attr = attr_fs_to_fuse(&path, 42, &fs::symlink_metadata(&path).unwrap());
+        // We cannot really make any useful assertions on ctime and crtime as these cannot be
+        // modified and may not be queryable, so stub them out.
+        attr.ctime = BAD_TIME;
+        attr.crtime = BAD_TIME;
+        assert_fileattrs_eq(&exp_attr, &attr);
+    }
+}

--- a/src/nodes/conv.rs
+++ b/src/nodes/conv.rs
@@ -198,8 +198,16 @@ mod tests {
     /// Sets the atime and mtime of a file to the given values.
     fn utimes(path: &Path, atime: &Timespec, mtime: &Timespec) {
         let times = [
-            libc::timeval { tv_sec: atime.sec, tv_usec: atime.nsec / 1000 },
-            libc::timeval { tv_sec: mtime.sec, tv_usec: mtime.nsec / 1000 },
+            // The explicit casts below are required to deal with platform size differences in the
+            // libc::timeval definition.
+            libc::timeval {
+                tv_sec: atime.sec as libc::time_t,
+                tv_usec: atime.nsec as libc::suseconds_t / 1000,
+            },
+            libc::timeval {
+                tv_sec: mtime.sec as libc::time_t,
+                tv_usec: mtime.nsec as libc::suseconds_t / 1000,
+            },
         ];
         let path = path.as_os_str().to_str().unwrap().as_bytes();
         let path = CString::new(path).unwrap();

--- a/src/nodes/conv.rs
+++ b/src/nodes/conv.rs
@@ -179,16 +179,11 @@ mod tests {
         assert_eq!(BAD_TIME, timespec);
     }
 
-    /// Sets the permissions of a file to exactly those given, bypassing the umask.
-    fn chmod_exactly(path: &Path, perm: libc::mode_t) {
+    /// Sets the permissions of a file to exactly those given.
+    fn chmod(path: &Path, perm: libc::mode_t) {
         let path = path.as_os_str().to_str().unwrap().as_bytes();
         let path = CString::new(path).unwrap();
-        assert_eq!(0, unsafe {
-            let old_umask = libc::umask(0);
-            let ret = libc::chmod(path.as_ptr(), perm);
-            libc::umask(old_umask);
-            ret
-        });
+        assert_eq!(0, unsafe { libc::chmod(path.as_ptr(), perm) });
     }
 
     /// Creates a block or character device and enforces that it is created successfully.
@@ -312,7 +307,7 @@ mod tests {
         fs::create_dir(path.join("subdir1")).unwrap();
         fs::create_dir(path.join("subdir2")).unwrap();
 
-        chmod_exactly(&path, 0o750);
+        chmod(&path, 0o750);
         let atime = Timespec { sec: 12345, nsec: 0 };
         let mtime = Timespec { sec: 678, nsec: 0 };
         utimes(&path, &atime, &mtime);
@@ -352,7 +347,7 @@ mod tests {
         file.write_all(content.as_bytes()).unwrap();
         drop(file);
 
-        chmod_exactly(&path, 0o640);
+        chmod(&path, 0o640);
         let atime = Timespec { sec: 54321, nsec: 0 };
         let mtime = Timespec { sec: 876, nsec: 0 };
         utimes(&path, &atime, &mtime);

--- a/src/nodes/conv.rs
+++ b/src/nodes/conv.rs
@@ -113,7 +113,7 @@ pub fn attr_fs_to_fuse(path: &Path, inode: u64, attr: &fs::Metadata) -> fuse::Fi
                 mode, path);
             0o400
         },
-        mode => (mode as u16) & !libc::S_IFMT,
+        mode => (mode as u16) & !(libc::S_IFMT as u16),
     };
 
     let rdev = match attr.rdev() {

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -16,12 +16,12 @@ extern crate fuse;
 extern crate libc;
 extern crate time;
 
-use super::conv;
+use self::time::Timespec;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use self::time::Timespec;
+use super::conv;
 use super::KernelError;
 use super::Node;
 use super::NodeResult;

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -14,8 +14,10 @@
 
 use fuse;
 use std::ffi::OsStr;
+use std::io;
 use std::sync::Arc;
 
+mod conv;
 mod dir;
 pub use self::dir::Dir;
 
@@ -35,6 +37,12 @@ impl KernelError {
     /// Obtains the errno code contained in this error, which can be fed back into the kernel.
     pub fn errno(&self) -> i32 {
         self.errno
+    }
+}
+
+impl From<io::Error> for KernelError {
+    fn from(e: io::Error) -> Self {
+        KernelError::from_errno(e.raw_os_error().unwrap())
     }
 }
 


### PR DESCRIPTION
This change starts to add support for directory nodes backed by other
directories in the file system, but only implements getattr on them so
far.  The reason is that the logic to manipulate stat data is complex
enough on its own so submitting it as a separate change will help with
the review process.  As a result, this change is pretty much useless
on its own.

I have tested that this works by mapping an arbitrary directory to the
root of the sandbox and ensuring that "stat" on it yields the desired
data.  We'll be able to enable more comprehensive integration tests
once the implementation of the directory is more complete.