### PR TITLE
Clippy

### DIFF
--- a/.vscode/settings.json.in
+++ b/.vscode/settings.json.in
@@ -25,6 +25,9 @@
   "go.toolsGopath": "__TOOLS_GOPATH__",
   "go.useLanguageServer": true,
 
+  "rust.cfg_test": true,
+  "rust.clippy_preference": "on",
+
   "[go]": {
     "editor.insertSpaces": false,
     "editor.rulers": [100],

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -67,6 +67,7 @@ do_gotools() {
 
 do_lint() {
   bazel run //admin/lint -- --verbose
+  PATH="${HOME}/.cargo/bin:${PATH}" cargo clippy -- -D warnings
 }
 
 do_rust() {

--- a/admin/travis-install.sh
+++ b/admin/travis-install.sh
@@ -76,6 +76,9 @@ case "${DO}" in
 
   lint)
     install_bazel
+    install_fuse  # Needed by Clippy to build the fuse Rust dependency.
+    install_rust
+    rustup component add clippy-preview
     ;;
 
   rust)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl Mapping {
     pub fn new(path: PathBuf, underlying_path: PathBuf, writable: bool)
         -> Result<Mapping, PathNotAbsoluteError> {
         if !path.is_absolute() {
-            return Err(PathNotAbsoluteError { path: path });
+            return Err(PathNotAbsoluteError { path });
         }
         if !underlying_path.is_absolute() {
             return Err(PathNotAbsoluteError { path: underlying_path });
@@ -149,7 +149,7 @@ impl fuse::Filesystem for SandboxFS {
 }
 
 /// Mounts a new sandboxfs instance on the given `mount_point` and maps all `mappings` within it.
-pub fn mount(mount_point: &Path, mappings: &Vec<Mapping>) -> io::Result<()> {
+pub fn mount(mount_point: &Path, mappings: &[Mapping]) -> io::Result<()> {
     let options = ["-o", "ro", "-o", "fsname=sandboxfs"]
         .iter()
         .map(|o| o.as_ref())

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn parse_mappings<T: AsRef<str>, U: IntoIterator<Item=T>>(args: U)
     for arg in args {
         let arg = arg.as_ref();
 
-        let fields: Vec<&str> = arg.split(":").collect();
+        let fields: Vec<&str> = arg.split(':').collect();
         if fields.len() != 3 {
             let message = format!("bad mapping {}: expected three colon-separated fields", arg);
             return Err(UsageError { message });

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -46,6 +46,7 @@ impl Dir {
     pub fn new_root(time: Timespec, uid: u32, gid: u32) -> Arc<Node> {
         let inode = fuse::FUSE_ROOT_ID;
 
+        #[cfg_attr(feature = "cargo-clippy", allow(redundant_field_names))]
         let attr = fuse::FileAttr {
             ino: inode,
             kind: fuse::FileType::Directory,
@@ -79,11 +80,11 @@ impl Node for Dir {
 
     fn getattr(&self) -> NodeResult<fuse::FileAttr> {
         let state = self.state.lock().unwrap();
-        Ok(state.attr.clone())
+        Ok(state.attr)
     }
 
     fn lookup(&self, _name: &OsStr) -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
-        return Err(KernelError::from_errno(libc::ENOENT));
+        Err(KernelError::from_errno(libc::ENOENT))
     }
 
     fn readdir(&self, reply: &mut fuse::ReplyDirectory) -> NodeResult<()> {

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -34,7 +34,7 @@ impl KernelError {
 
     /// Obtains the errno code contained in this error, which can be fed back into the kernel.
     pub fn errno(&self) -> i32 {
-        return self.errno;
+        self.errno
     }
 }
 


### PR DESCRIPTION
Miscellaneous changes to enable Clippy and fix Rust warnings.

Not bothering to send separate PRs for each commit because they are trivial. Will "rebase and merge" once approved, not squash.