### PR TITLE
Simplify and generalize some test code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,16 @@ travis-ci = { repository = "bazelbuild/sandboxfs", branch = "master" }
 [dependencies]
 env_logger = "0.5"
 failure = "0.1"
-fuse = "0.3"
 getopts = "0.2"
 libc = "0.2"
 log = "0.4"
 time = "0.1"
+
+[dependencies.fuse]
+# TODO(https://github.com/zargony/rust-fuse/pull/111): Replace this with
+# the upstream address (or a Crates release) once incorporated.
+git = "https://github.com/jmmv/rust-fuse.git"
+rev = "152d2ad2fa8831be33fa5e691cc59ce9c51ece7a"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ use std::sync::{Arc, Mutex};
 use time::Timespec;
 
 mod nodes;
+#[cfg(test)] mod testutils;
 
 // TODO(jmmv): Make configurable via a flag and store inside SandboxFS.
 pub const TTL: Timespec = Timespec { sec: 60, nsec: 0 };

--- a/src/nodes/conv.rs
+++ b/src/nodes/conv.rs
@@ -280,27 +280,6 @@ mod tests {
             fuse::FileType::Symlink, |path| { unix::fs::symlink("irrelevant", &path).unwrap(); });
     }
 
-    /// Asserts that two FUSE file attributes are equal.
-    ///
-    /// TODO(jmmv): Upstream an Eq implementation for fuse::Fileattr so that this becomes more
-    /// reliable and can provide nicer diagnostics on differences.
-    fn assert_fileattrs_eq(attr1: &fuse::FileAttr, attr2: &fuse::FileAttr) {
-        assert_eq!(attr1.ino, attr2.ino);
-        assert_eq!(attr1.kind, attr2.kind);
-        assert_eq!(attr1.nlink, attr2.nlink);
-        assert_eq!(attr1.size, attr2.size);
-        assert_eq!(attr1.blocks, attr2.blocks);
-        assert_eq!(attr1.atime, attr2.atime);
-        assert_eq!(attr1.mtime, attr2.mtime);
-        assert_eq!(attr1.ctime, attr2.ctime);
-        assert_eq!(attr1.crtime, attr2.crtime);
-        assert_eq!(attr1.perm, attr2.perm);
-        assert_eq!(attr1.uid, attr2.uid);
-        assert_eq!(attr1.gid, attr2.gid);
-        assert_eq!(attr1.rdev, attr2.rdev);
-        assert_eq!(attr1.flags, attr2.flags);
-    }
-
     #[test]
     fn test_attr_fs_to_fuse_directory() {
         let dir = TempDir::new("test").unwrap();
@@ -336,7 +315,7 @@ mod tests {
         // modified and may not be queryable, so stub them out.
         attr.ctime = BAD_TIME;
         attr.crtime = BAD_TIME;
-        assert_fileattrs_eq(&exp_attr, &attr);
+        assert_eq!(&exp_attr, &attr);
     }
 
     #[test]
@@ -376,6 +355,6 @@ mod tests {
         // modified and may not be queryable, so stub them out.
         attr.ctime = BAD_TIME;
         attr.crtime = BAD_TIME;
-        assert_fileattrs_eq(&exp_attr, &attr);
+        assert_eq!(&exp_attr, &attr);
     }
 }

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1,0 +1,96 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+#![cfg(test)]
+
+use fuse;
+use libc;
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::fs;
+use std::os::unix;
+use std::path::{Path, PathBuf};
+use tempdir::TempDir;
+
+/// Creates a block or character device and enforces that it is created successfully.
+fn mkdev(path: &Path, type_mask: libc::mode_t, dev: libc::dev_t) {
+    assert!(type_mask == libc::S_IFBLK || type_mask == libc::S_IFCHR);
+    let path = path.as_os_str().to_str().unwrap().as_bytes();
+    let path = CString::new(path).unwrap();
+    assert_eq!(0, unsafe { libc::mknod(path.as_ptr(), 0o444 | type_mask, dev) });
+}
+
+/// Creates a named pipe and enforces that it is created successfully.
+fn mkfifo(path: &Path) {
+    let path = path.as_os_str().to_str().unwrap().as_bytes();
+    let path = CString::new(path).unwrap();
+    assert_eq!(0, unsafe { libc::mkfifo(path.as_ptr(), 0o444) });
+}
+
+/// Holds a temporary directory and files of all possible kinds within it.
+///
+/// The directory (including all of its contents) is removed when this object is dropped.
+pub struct AllFileTypes {
+    #[allow(unused)]  // Must retain to delay directory deletion.
+    root: TempDir,
+
+    /// Collection of test files keyed by their type.
+    ///
+    /// Tests should iterate over this map and consume all entries to ensure all possible file types
+    /// are verified everywhere.  Prefer using `match` on the key to achieve this.
+    pub entries: HashMap<fuse::FileType, PathBuf>,
+}
+
+impl AllFileTypes {
+    /// Creates a new temporary directory with files of all possible kinds within it.
+    pub fn new() -> Self {
+        let root = TempDir::new("test").unwrap();
+
+        let mut entries: HashMap<fuse::FileType, PathBuf> = HashMap::new();
+
+        if unsafe { libc::getuid() } == 0 {
+            let block_device = root.path().join("block_device");
+            mkdev(&block_device, libc::S_IFBLK, 50);
+            entries.insert(fuse::FileType::BlockDevice, block_device);
+
+            let char_device = root.path().join("char_device");
+            mkdev(&char_device, libc::S_IFCHR, 50);
+            entries.insert(fuse::FileType::CharDevice, char_device);
+        } else {
+            warn!("Not running as root; cannot create block/char devices");
+        }
+
+        let directory = root.path().join("dir");
+        fs::create_dir(&directory).unwrap();
+        entries.insert(fuse::FileType::Directory, directory);
+
+        let named_pipe = root.path().join("named_pipe");
+        mkfifo(&named_pipe);
+        entries.insert(fuse::FileType::NamedPipe, named_pipe);
+
+        let regular = root.path().join("regular");
+        drop(fs::File::create(&regular).unwrap());
+        entries.insert(fuse::FileType::RegularFile, regular);
+
+        let socket = root.path().join("socket");
+        drop(unix::net::UnixListener::bind(&socket).unwrap());
+        entries.insert(fuse::FileType::Socket, socket);
+
+        let symlink = root.path().join("symlink");
+        unix::fs::symlink("irrelevant", &symlink).unwrap();
+        entries.insert(fuse::FileType::Symlink, symlink);
+
+        AllFileTypes { root, entries }
+    }
+}


### PR DESCRIPTION
A couple of commits that will be rebased on top of master and fast-forwarded once approved.

One is to remove a lot of custom code thanks to an upstream change (still waiting to be merged, but didn't want to hold getting this review out).

Another one is to generalize some test boilerplate so I can reuse it in an upcoming change. The upcoming change will add the ability to instantiate `Node`s of various types and I need to ensure that such logic can deal with all possible file types as well, hence `AllFileTypes` being generic is a good thing.