### PR TITLE
Add a cache for nodes and barebones file/symlink nodes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ impl IdGenerator {
 
     /// Obtains a new identifier.
     pub fn next(&self) -> u64 {
-        let id = self.last_id.fetch_add(1, Ordering::SeqCst);
+        let id = self.last_id.fetch_add(1, Ordering::AcqRel);
         // TODO(https://github.com/rust-lang/rust/issues/51577): Drop :: prefix.
         if id >= ::std::u64::MAX as usize {
             panic!("Ran out of identifiers");

--- a/src/nodes/file.rs
+++ b/src/nodes/file.rs
@@ -1,0 +1,94 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+extern crate fuse;
+extern crate libc;
+extern crate time;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use super::conv;
+use super::Node;
+use super::NodeResult;
+
+/// Representation of a file node.
+///
+/// File nodes represent all kinds of files (except for directories and symlinks), not just regular
+/// files, because the set of node operations required by them is the same.
+pub struct File {
+    inode: u64,
+    writable: bool,
+    state: Mutex<MutableFile>,
+}
+
+/// Holds the mutable data of a file node.
+struct MutableFile {
+    underlying_path: Option<PathBuf>,
+    attr: fuse::FileAttr,
+}
+
+impl File {
+    /// Returns true if this node can represent the given file type.
+    fn supports_type(t: fs::FileType) -> bool {
+        !t.is_dir() && !t.is_symlink()
+    }
+
+    /// Creates a new file backed by a file on an underlying file system.
+    ///
+    /// `inode` is the node number to assign to the created in-memory file and has no relation
+    /// to the underlying file.  `underlying_path` indicates the path to the file outside
+    /// of the sandbox that backs this one.  `fs_attr` contains the stat data for the given path.
+    ///
+    /// `fs_attr` is an input parameter because, by the time we decide to instantiate a file
+    /// node (e.g. as we discover directory entries during readdir or lookup), we have already
+    /// issued a stat on the underlying file system and we cannot re-do it for efficiency reasons.
+    pub fn new_mapped(inode: u64, underlying_path: &Path, fs_attr: &fs::Metadata, writable: bool)
+        -> Arc<Node> {
+        if !File::supports_type(fs_attr.file_type()) {
+            panic!("Can only construct based on non-directories / non-symlinks");
+        }
+        let attr = conv::attr_fs_to_fuse(underlying_path, inode, &fs_attr);
+
+        let state = MutableFile {
+            underlying_path: Some(PathBuf::from(underlying_path)),
+            attr,
+        };
+
+        Arc::new(File { inode, writable, state: Mutex::from(state) })
+    }
+}
+
+impl Node for File {
+    fn inode(&self) -> u64 {
+        self.inode
+    }
+
+    fn writable(&self) -> bool {
+        self.writable
+    }
+
+    fn getattr(&self) -> NodeResult<fuse::FileAttr> {
+        let mut state = self.state.lock().unwrap();
+
+        let check_type = |t: fs::FileType|
+            if File::supports_type(t) { Ok(()) } else { Err("non-directory / non-symlink") };
+        if let Some(attr) = super::get_new_attr(
+            self.inode, state.underlying_path.as_ref(), check_type)? {
+            state.attr = attr;
+        }
+
+        Ok(state.attr)
+    }
+}

--- a/src/nodes/symlink.rs
+++ b/src/nodes/symlink.rs
@@ -1,0 +1,85 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+extern crate fuse;
+extern crate libc;
+extern crate time;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use super::conv;
+use super::Node;
+use super::NodeResult;
+
+/// Representation of a symlink node.
+pub struct Symlink {
+    inode: u64,
+    writable: bool,
+    state: Mutex<MutableSymlink>,
+}
+
+/// Holds the mutable data of a symlink node.
+struct MutableSymlink {
+    underlying_path: Option<PathBuf>,
+    attr: fuse::FileAttr,
+}
+
+impl Symlink {
+    /// Creates a new symlink backed by a symlink on an underlying file system.
+    ///
+    /// `inode` is the node number to assign to the created in-memory symlink and has no relation
+    /// to the underlying symlink.  `underlying_path` indicates the path to the symlink outside
+    /// of the sandbox that backs this one.  `fs_attr` contains the stat data for the given path.
+    ///
+    /// `fs_attr` is an input parameter because, by the time we decide to instantiate a symlink
+    /// node (e.g. as we discover directory entries during readdir or lookup), we have already
+    /// issued a stat on the underlying file system and we cannot re-do it for efficiency reasons.
+    pub fn new_mapped(inode: u64, underlying_path: &Path, fs_attr: &fs::Metadata, writable: bool)
+        -> Arc<Node> {
+        if !fs_attr.file_type().is_symlink() {
+            panic!("Can only construct based on symlinks");
+        }
+        let attr = conv::attr_fs_to_fuse(underlying_path, inode, &fs_attr);
+
+        let state = MutableSymlink {
+            underlying_path: Some(PathBuf::from(underlying_path)),
+            attr,
+        };
+
+        Arc::new(Symlink { inode, writable, state: Mutex::from(state) })
+    }
+}
+
+impl Node for Symlink {
+    fn inode(&self) -> u64 {
+        self.inode
+    }
+
+    fn writable(&self) -> bool {
+        self.writable
+    }
+
+    fn getattr(&self) -> NodeResult<fuse::FileAttr> {
+        let mut state = self.state.lock().unwrap();
+
+        let check_type = |t: fs::FileType| if t.is_symlink() { Ok(()) } else { Err("symlink") };
+        if let Some(attr) = super::get_new_attr(
+            self.inode, state.underlying_path.as_ref(), check_type)? {
+            state.attr = attr;
+        };
+
+        Ok(state.attr)
+    }
+}


### PR DESCRIPTION
This PR is a bit long, sorry! But a couple of things that should make the review easier: the new `file.rs` and `symlink.rs` are pretty much duplicates. I find this unfortunate but cannot think of a way to remove the duplication. Doesn't bother me much because it's trivial though, and these files will later grow to contain node-specific logic. Also, there is quite a bunch of new test code here that bloats this PR; the actual new logic is all within `lib.rs`.

There are a bunch of TODOs in this new code, but I'm just trying to replicate the exact same functionality in the Go version of this codebase. (Most of the comments and TODOs come from there, as well as the general design.) I'd rather not change the design much (other than for making it Rust-friendly) because it'll be easier to make this reimplementation work with the existing workloads that the Go one supports.

----- Commit description -----

This change adds a factory for nodes in the form of a cache.  The cache
tracks nodes that map to specific underlying files across different
reconfigurations so that we don't lose precious in-kernel state for
files that may be mapped and unmapped many times.  This is specifically
useful in the context of a Bazel build where an action may need to map
the C++ compiler, the following may not need it, but a next one may
need it again: if we don't maintain the node, the kernel will think the
compiler is a different file each time and will have to reload it from
disk.

To make the cache functional, this change also adds barebone
implementations for all other node types we will need, namely File and
Symlink, and adds a "writable" property to each node.

Note, however, that this code is pretty much useless as it is because
the only call we have now is to create the node for the mount point.
This will become useful in the next commit, where I'll implement
read-only mapped directories (i.e. their readdir and lookup operations).