### PR TITLE
Implement read-only directories (lookup and readdir)

### DIFF
--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -102,11 +102,9 @@ do_rust() {
     TestReadOnly_DirectoryStructure
     TestReadOnly_FileContents
     TestReadOnly_ReplaceUnderlyingFile
-    TestReadOnly_MoveUnderlyingDirectory
     TestReadOnly_TargetDoesNotExist
     TestReadOnly_RepeatedReadDirsWhileDirIsOpen
     TestReadOnly_Attributes
-    TestReadOnly_Access
     TestReadOnly_HardLinkCountsAreFixed
     TestReadWrite_CreateFile
     TestReadWrite_Remove

--- a/src/nodes/conv.rs
+++ b/src/nodes/conv.rs
@@ -58,7 +58,7 @@ fn system_time_to_timespec(path: &Path, name: &str, time: &io::Result<SystemTime
 /// If the given file type cannot be mapped to a FUSE file type (because we don't know about that
 /// type or, most likely, because the file type is bogus), logs a warning and returns a regular
 /// file type with the assumption that most operations should work on it.
-fn filetype_fs_to_fuse(path: &Path, fs_type: fs::FileType) -> fuse::FileType {
+pub fn filetype_fs_to_fuse(path: &Path, fs_type: fs::FileType) -> fuse::FileType {
     if fs_type.is_block_device() {
         fuse::FileType::BlockDevice
     } else if fs_type.is_char_device() {

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -16,8 +16,10 @@ extern crate fuse;
 extern crate libc;
 extern crate time;
 
+use {Cache, IdGenerator};
 use self::time::Timespec;
-use std::ffi::OsStr;
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -38,6 +40,7 @@ struct MutableDir {
     parent: u64,
     underlying_path: Option<PathBuf>,
     attr: fuse::FileAttr,
+    children: HashMap<OsString, Arc<Node>>,
 }
 
 impl Dir {
@@ -69,10 +72,12 @@ impl Dir {
             flags: 0,
         };
 
+        #[cfg_attr(feature = "cargo-clippy", allow(redundant_field_names))]
         let state = MutableDir {
             parent: inode,
             underlying_path: None,
-            attr,
+            attr: attr,
+            children: HashMap::new(),
         };
 
         Arc::new(Dir {
@@ -98,10 +103,12 @@ impl Dir {
         }
         let attr = conv::attr_fs_to_fuse(underlying_path, inode, &fs_attr);
 
+        #[cfg_attr(feature = "cargo-clippy", allow(redundant_field_names))]
         let state = MutableDir {
             parent: inode,
             underlying_path: Some(PathBuf::from(underlying_path)),
-            attr,
+            attr: attr,
+            children: HashMap::new(),
         };
 
         Arc::new(Dir { inode, writable, state: Mutex::from(state) })
@@ -129,15 +136,60 @@ impl Node for Dir {
         Ok(state.attr)
     }
 
-    fn lookup(&self, _name: &OsStr) -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
-        Err(KernelError::from_errno(libc::ENOENT))
+    fn lookup(&self, name: &OsStr, ids: &IdGenerator, cache: &Cache)
+        -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
+        let mut state = self.state.lock().unwrap();
+
+        if let Some(node) = state.children.get(name) {
+            let refreshed_attr = node.getattr()?;
+            return Ok((node.clone(), refreshed_attr))
+        }
+
+        let (child, attr) = {
+            let path = match state.underlying_path.as_ref() {
+                Some(underlying_path) => underlying_path.join(name),
+                None => return Err(KernelError::from_errno(libc::ENOENT)),
+            };
+            let fs_attr = fs::symlink_metadata(&path)?;
+            let node = cache.get_or_create(ids, &path, &fs_attr, self.writable);
+            let attr = conv::attr_fs_to_fuse(path.as_path(), node.inode(), &fs_attr);
+            (node, attr)
+        };
+        state.children.insert(name.to_os_string(), child.clone());
+        Ok((child, attr))
     }
 
-    fn readdir(&self, reply: &mut fuse::ReplyDirectory) -> NodeResult<()> {
-        let state = self.state.lock().unwrap();
+    fn readdir(&self, ids: &IdGenerator, cache: &Cache, reply: &mut fuse::ReplyDirectory)
+        -> NodeResult<()> {
+        let mut state = self.state.lock().unwrap();
 
         reply.add(self.inode, 0, fuse::FileType::Directory, ".");
         reply.add(state.parent, 1, fuse::FileType::Directory, "..");
+        let mut pos = 2;
+
+        // TODO(jmmv): Handle user-provided mappings before underlying entries.
+
+        if state.underlying_path.as_ref().is_none() {
+            return Ok(());
+        }
+
+        let entries = fs::read_dir(state.underlying_path.as_ref().unwrap())?;
+        for entry in entries {
+            let entry = entry?;
+            let name = entry.file_name();
+            let fs_attr = entry.metadata()?;
+
+            let path = state.underlying_path.as_ref().unwrap().join(&name);
+            let child = cache.get_or_create(ids, &path, &fs_attr, self.writable);
+
+            reply.add(child.inode(), pos,
+                conv::filetype_fs_to_fuse(&path, fs_attr.file_type()), &name);
+            // Do the insertion into state.children after calling reply.add() to be able to move
+            // the name into the key without having to copy it again.
+            state.children.insert(name, child.clone());
+
+            pos += 1;
+        }
         Ok(())
     }
 }

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -90,7 +90,11 @@ pub trait Node {
     ///
     /// The attributes are returned to avoid having to relock the node on the caller side in order
     /// to supply those attributes to the kernel.
-    fn lookup(&self, _name: &OsStr) -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
+    ///
+    /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
+    /// nodes, used when lookup discovers an underlying node that was not yet known.
+    fn lookup(&self, _name: &OsStr, _ids: &super::IdGenerator, _cache: &super::Cache)
+        -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
         panic!("Not implemented");
     }
 
@@ -98,7 +102,11 @@ pub trait Node {
     ///
     /// It is the responsibility of the caller to invoke `reply.ok()` on the reply object.  This is
     /// for consistency with the handling of any errors returned by this function.
-    fn readdir(&self, _reply: &mut fuse::ReplyDirectory) -> NodeResult<()> {
+    ///
+    /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
+    /// nodes, used when readdir discovers an underlying node that was not yet known.
+    fn readdir(&self, _ids: &super::IdGenerator, _cache: &super::Cache,
+        _reply: &mut fuse::ReplyDirectory) -> NodeResult<()> {
         panic!("Not implemented");
     }
 }


### PR DESCRIPTION
Starting to become functional, but not enough to enable significant tests yet. The next steps will be to implement read-only files, (which I'm not doing now because they require boilerplate to handle open file handles), symlinks, and nested mappings. With these two, we should be able to enable a bunch of integration tests, and possibly need to fix bugs.

Thanks again!