### PR TITLE
Implement read-only nodes

### DIFF
--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -100,8 +100,6 @@ do_rust() {
     TestProfiling_FileProfiles
     TestProfiling_BadConfiguration
     TestReadOnly_DirectoryStructure
-    TestReadOnly_FileContents
-    TestReadOnly_ReplaceUnderlyingFile
     TestReadOnly_TargetDoesNotExist
     TestReadOnly_RepeatedReadDirsWhileDirIsOpen
     TestReadOnly_Attributes

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -102,11 +102,9 @@ do_rust() {
     TestReadOnly_DirectoryStructure
     TestReadOnly_FileContents
     TestReadOnly_ReplaceUnderlyingFile
-    TestReadOnly_MoveUnderlyingDirectory
     TestReadOnly_TargetDoesNotExist
     TestReadOnly_RepeatedReadDirsWhileDirIsOpen
     TestReadOnly_Attributes
-    TestReadOnly_Access
     TestReadOnly_HardLinkCountsAreFixed
     TestReadWrite_CreateFile
     TestReadWrite_Remove

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fs;
 use std::io;
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::result::Result;
 use std::sync::{Arc, Mutex};
@@ -276,6 +277,14 @@ impl fuse::Filesystem for SandboxFS {
             // completed the first read and is asking us for extra entries -- of which there will
             // be none.
             reply.ok();
+        }
+    }
+
+    fn readlink(&mut self, _req: &fuse::Request, inode: u64, reply: fuse::ReplyData) {
+        let node = self.find_node(inode);
+        match node.readlink() {
+            Ok(target) => reply.data(target.as_os_str().as_bytes()),
+            Err(e) => reply.error(e.errno_as_i32()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,8 +173,14 @@ impl Cache {
 
 /// FUSE file system implementation of sandboxfs.
 struct SandboxFS {
+    /// Monotonically-increasing generator of identifiers for this file system instance.
+    ids: IdGenerator,
+
     /// Mapping of inode numbers to in-memory nodes that tracks all files known by sandboxfs.
     nodes: Arc<Mutex<HashMap<u64, Arc<nodes::Node>>>>,
+
+    /// Cache of sandboxfs nodes indexed by their underlying path.
+    cache: Arc<Cache>,
 }
 
 impl SandboxFS {
@@ -209,7 +215,9 @@ impl SandboxFS {
         nodes.insert(root.inode(), root);
 
         Ok(SandboxFS {
+            ids: ids,
             nodes: Arc::from(Mutex::from(nodes)),
+            cache: Arc::from(cache),
         })
     }
 
@@ -239,7 +247,7 @@ impl fuse::Filesystem for SandboxFS {
 
     fn lookup(&mut self, _req: &fuse::Request, parent: u64, name: &OsStr, reply: fuse::ReplyEntry) {
         let dir_node = self.find_node(parent);
-        match dir_node.lookup(name) {
+        match dir_node.lookup(name, &self.ids, &self.cache) {
             Ok((node, attr)) => {
                 {
                     let mut nodes = self.nodes.lock().unwrap();
@@ -257,7 +265,7 @@ impl fuse::Filesystem for SandboxFS {
                mut reply: fuse::ReplyDirectory) {
         if offset == 0 {
             let node = self.find_node(inode);
-            match node.readdir(&mut reply) {
+            match node.readdir(&self.ids, &self.cache, &mut reply) {
                 Ok(()) => reply.ok(),
                 Err(e) => reply.error(e.errno_as_i32()),
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+#![cfg_attr(feature = "cargo-clippy", allow(redundant_field_names))]
+
 #[macro_use] extern crate failure;
 extern crate fuse;
 #[macro_use] extern crate log;

--- a/src/nodes/conv.rs
+++ b/src/nodes/conv.rs
@@ -87,7 +87,6 @@ fn filetype_fs_to_fuse(path: &Path, fs_type: fs::FileType) -> fuse::FileType {
 ///
 /// Any errors encountered along the conversion process are logged and the corresponding field is
 /// replaced by a reasonable value that should work.  In other words: all errors are swallowed.
-#[cfg_attr(feature = "cargo-clippy", allow(redundant_field_names))]
 pub fn attr_fs_to_fuse(path: &Path, inode: u64, attr: &fs::Metadata) -> fuse::FileAttr {
     let nlink = if attr.is_dir() {
         2  // "." entry plus whichever initial named node points at this.

--- a/src/nodes/conv.rs
+++ b/src/nodes/conv.rs
@@ -58,7 +58,7 @@ fn system_time_to_timespec(path: &Path, name: &str, time: &io::Result<SystemTime
 /// If the given file type cannot be mapped to a FUSE file type (because we don't know about that
 /// type or, most likely, because the file type is bogus), logs a warning and returns a regular
 /// file type with the assumption that most operations should work on it.
-fn filetype_fs_to_fuse(path: &Path, fs_type: fs::FileType) -> fuse::FileType {
+pub fn filetype_fs_to_fuse(path: &Path, fs_type: fs::FileType) -> fuse::FileType {
     if fs_type.is_block_device() {
         fuse::FileType::BlockDevice
     } else if fs_type.is_char_device() {

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -51,7 +51,6 @@ impl Dir {
     pub fn new_root(time: Timespec, uid: unistd::Uid, gid: unistd::Gid) -> Arc<Node> {
         let inode = fuse::FUSE_ROOT_ID;
 
-        #[cfg_attr(feature = "cargo-clippy", allow(redundant_field_names))]
         let attr = fuse::FileAttr {
             ino: inode,
             kind: fuse::FileType::Directory,

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -16,6 +16,7 @@ use fuse;
 use nix::errno::Errno;
 use std::ffi::OsStr;
 use std::io;
+use std::path::PathBuf;
 use std::result::Result;
 use std::sync::Arc;
 
@@ -107,6 +108,11 @@ pub trait Node {
     /// nodes, used when readdir discovers an underlying node that was not yet known.
     fn readdir(&self, _ids: &super::IdGenerator, _cache: &super::Cache,
         _reply: &mut fuse::ReplyDirectory) -> NodeResult<()> {
+        panic!("Not implemented");
+    }
+
+    /// Reads the target of a symlink.
+    fn readlink(&self) -> NodeResult<PathBuf> {
         panic!("Not implemented");
     }
 }

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -88,15 +88,25 @@ pub trait Node {
     ///
     /// The attributes are returned to avoid having to relock the node on the caller side in order
     /// to supply those attributes to the kernel.
-    fn lookup(&self, _name: &OsStr) -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
+    ///
+    /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
+    /// nodes, used when lookup discovers an underlying node that was not yet known.
+    fn lookup(&self, _name: &OsStr, _ids: &super::IdGenerator, _cache: &super::Cache)
+        -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
         panic!("Not implemented");
     }
 
     /// Reads all directory entries into the given reply object.
     ///
-    /// It is the responsibility of the caller to invoke `reply.ok()` on the reply object.  This is
-    /// for consistency with the handling of any errors returned by this function.
-    fn readdir(&self, _reply: &mut fuse::ReplyDirectory) -> NodeResult<()> {
+    /// While this takes a `fuse::ReplyDirectory` object as a parameter for efficiency reasons, it
+    /// is the responsibility of the caller to invoke `reply.ok()` and `reply.error()` on the same
+    /// reply object.  This is for consistency with the handling of any errors returned by this and
+    /// other functions.
+    ///
+    /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
+    /// nodes, used when readdir discovers an underlying node that was not yet known.
+    fn readdir(&self, _ids: &super::IdGenerator, _cache: &super::Cache,
+        _reply: &mut fuse::ReplyDirectory) -> NodeResult<()> {
         panic!("Not implemented");
     }
 }

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -15,9 +15,7 @@
 use fuse;
 use nix::errno::Errno;
 use std::ffi::OsStr;
-use std::fs;
 use std::io;
-use std::path::PathBuf;
 use std::result::Result;
 use std::sync::Arc;
 
@@ -100,35 +98,5 @@ pub trait Node {
     /// for consistency with the handling of any errors returned by this function.
     fn readdir(&self, _reply: &mut fuse::ReplyDirectory) -> NodeResult<()> {
         panic!("Not implemented");
-    }
-}
-
-/// Computes the new attributes for a node.
-///
-/// This is a helper function for the implementation of `getattr` and, as such, its signature is
-/// tightly coupled to the needs of that function.
-///
-/// `inode` is the inode number that the node has within sandboxfs.  `path` is the underlying path
-/// that the node is mapped to, or none if it's not mapped.  `check_type` is a lambda that validates
-/// the file type we obtain from a stat operation and returns the user-facing name of the node type
-/// as an error on a mismatch.
-///
-/// Returns the new attributes if the ones in the node have to be updated, or none if there are no
-/// attributes to update.
-pub fn get_new_attr<T>(inode: u64, path: Option<&PathBuf>, check_type: T)
-    -> NodeResult<Option<fuse::FileAttr>>
-    where T: Fn(fs::FileType) -> Result<(), &'static str>
-{
-    match path {
-        Some(path) => {
-            let fs_attr = fs::symlink_metadata(path)?;
-            if let Err(type_name) = check_type(fs_attr.file_type()) {
-                warn!("Path {:?} backing a {} node is no longer a {}; got {:?}",
-                        path, type_name, type_name, fs_attr.file_type());
-                return Err(KernelError::from_errno(Errno::EIO));
-            }
-            Ok(Some(conv::attr_fs_to_fuse(path, inode, &fs_attr)))
-        },
-        None => Ok(None),
     }
 }

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -62,6 +62,12 @@ impl From<io::Error> for KernelError {
 /// Generic result type for of all node operations.
 pub type NodeResult<T> = Result<T, KernelError>;
 
+/// Abstract representation of an open file handle.
+pub trait Handle {
+    /// Reads `size` bytes from the open file starting at `offset`.
+    fn read(&self, offset: i64, size: u32) -> NodeResult<Vec<u8>>;
+}
+
 /// Abstract representation of a file system node.
 ///
 /// Due to the way nodes and node operations are represented in the kernel, this trait exposes a
@@ -94,6 +100,11 @@ pub trait Node {
     /// nodes, used when lookup discovers an underlying node that was not yet known.
     fn lookup(&self, _name: &OsStr, _ids: &super::IdGenerator, _cache: &super::Cache)
         -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
+        panic!("Not implemented");
+    }
+
+    /// Opens the file and returns an open file handle for it.
+    fn open(&self, _flags: u32) -> NodeResult<Arc<Handle>> {
         panic!("Not implemented");
     }
 

--- a/src/nodes/symlink.rs
+++ b/src/nodes/symlink.rs
@@ -82,4 +82,10 @@ impl Node for Symlink {
 
         Ok(state.attr)
     }
+
+    fn readlink(&self) -> NodeResult<PathBuf> {
+        let state = self.state.lock().unwrap();
+
+        Ok(fs::read_link(&state.underlying_path)?)
+    }
 }


### PR DESCRIPTION
The three commits in this PR implement the read-only vnops needed for functional directories, symlinks, and files. Each commit is pretty much standalone and rather small, but to reduce turnaround times, I've combined them in a single review request. Hopefully that's not much trouble. Thanks!