### PR TITLE
Support multiple mappings

### DIFF
--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -85,24 +85,14 @@ do_rust() {
     TestCli_Syntax
     TestDebug_FuseOpsInLog
     TestLayout_MountPointDoesNotExist
-    TestLayout_RootMustBeDirectory
-    TestLayout_TargetDoesNotExist
-    TestLayout_DuplicateMapping
-    TestLayout_TargetIsScaffoldDirectory
-    TestNesting_ScaffoldIntermediateComponents
-    TestNesting_ScaffoldIntermediateComponentsAreImmutable
     TestNesting_ReadWriteWithinReadOnly
     TestNesting_SameTarget
-    TestNesting_PreserveSymlinks
     TestOptions_Allow
     TestOptions_Syntax
     TestProfiling_Http
     TestProfiling_FileProfiles
     TestProfiling_BadConfiguration
-    TestReadOnly_DirectoryStructure
-    TestReadOnly_RepeatedReadDirsWhileDirIsOpen
     TestReadOnly_Attributes
-    TestReadOnly_HardLinkCountsAreFixed
     TestReadWrite_CreateFile
     TestReadWrite_Remove
     TestReadWrite_RewriteFile

--- a/integration/layout_test.go
+++ b/integration/layout_test.go
@@ -55,7 +55,12 @@ func TestLayout_RootMustBeDirectory(t *testing.T) {
 	file := filepath.Join(tempDir, "file")
 	utils.MustWriteFile(t, file, 0644, "")
 
-	wantStderr := "unable to init sandbox: cannot map file " + file + " at root: must be a directory\n"
+	var wantStderr string
+	if utils.GetConfig().RustVariant {
+		wantStderr = "Failed to map root: .*" + file + ".* not a directory"
+	} else {
+		wantStderr = "unable to init sandbox: cannot map file " + file + " at root: must be a directory\n"
+	}
 
 	stdout, stderr, err := utils.RunAndWait(1, "--mapping=ro:/:"+file, "irrelevant-mount-point")
 	if err != nil {
@@ -70,7 +75,12 @@ func TestLayout_RootMustBeDirectory(t *testing.T) {
 }
 
 func TestLayout_TargetDoesNotExist(t *testing.T) {
-	wantStderr := "failed to stat /non-existent when mapping /.*\n"
+	var wantStderr string
+	if utils.GetConfig().RustVariant {
+		wantStderr = "Failed to map root: stat failed .*/non-existent"
+	} else {
+		wantStderr = "failed to stat /non-existent when mapping /.*\n"
+	}
 
 	stdout, stderr, err := utils.RunAndWait(1, "--mapping=ro:/:/non-existent", "irrelevant-mount-point")
 	if err != nil {
@@ -91,7 +101,12 @@ func TestLayout_DuplicateMapping(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	wantStderr := "unable to init sandbox: cannot map /a/a: already mapped\n"
+	var wantStderr string
+	if utils.GetConfig().RustVariant {
+		wantStderr = "Failed to map .*\"/a/a\".* Already mapped\n"
+	} else {
+		wantStderr = "unable to init sandbox: cannot map /a/a: already mapped\n"
+	}
 
 	path1 := filepath.Join(tempDir, "1")
 	utils.MustWriteFile(t, path1, 0644, "")
@@ -120,7 +135,12 @@ func TestLayout_TargetIsScaffoldDirectory(t *testing.T) {
 	file := filepath.Join(tempDir, "file")
 	utils.MustWriteFile(t, file, 0644, "")
 
-	wantStderr := "unable to init sandbox: cannot map /a: already mapped\n"
+	var wantStderr string
+	if utils.GetConfig().RustVariant {
+		wantStderr = "Failed to map .*\"/a\".* Already mapped"
+	} else {
+		wantStderr = "unable to init sandbox: cannot map /a: already mapped\n"
+	}
 
 	stdout, stderr, err := utils.RunAndWait(1, "--mapping=ro:/a/b/c:"+tempDir, "--mapping=ro:/a:"+file, "irrelevant-mount-point")
 	if err != nil {

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -16,14 +16,34 @@ extern crate fuse;
 extern crate time;
 
 use {Cache, IdGenerator};
+use failure::{Error, ResultExt};
 use nix::{errno, unistd};
 use nodes::{KernelError, Node, NodeResult, conv};
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::io;
+use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use time::Timespec;
+
+/// Takes the components of a path and returns the first normal component and the rest.
+///
+/// This assumes that the input path is normalized and that the very first component is a normal
+/// component as defined by `Component::Normal`.
+fn split_components<'a>(components: &'a [Component]) -> (&'a OsStr, &'a [Component<'a>]) {
+    assert!(!components.is_empty());
+    let name = match components[0] {
+        Component::Normal(name) => name,
+        _ => panic!("Input list of components is not normalized"),
+    };
+    (name, &components[1..])
+}
+
+/// Representation of a directory entry.
+struct Dirent {
+    node: Arc<Node>,
+    explicit_mapping: bool,
+}
 
 /// Representation of a directory node.
 pub struct Dir {
@@ -37,19 +57,16 @@ struct MutableDir {
     parent: u64,
     underlying_path: Option<PathBuf>,
     attr: fuse::FileAttr,
-    children: HashMap<OsString, Arc<Node>>,
+    children: HashMap<OsString, Dirent>,
 }
 
 impl Dir {
-    /// Creates a new scaffold directory to represent the root directory.
+    /// Creates a new scaffold directory to represent an in-memory directory.
     ///
-    /// `time` is the timestamp to be used for all node times.
-    ///
-    /// `uid` and `gid` indicate the ownership details of the node.  These should always match the
-    /// values of the currently-running process -- but not necessarily if we want to let users
-    /// customize these via flags at some point.
-    pub fn new_root(time: Timespec, uid: unistd::Uid, gid: unistd::Gid) -> Arc<Node> {
-        let inode = fuse::FUSE_ROOT_ID;
+    /// The directory's timestamps are all set to the current time, and the ownership is set to the
+    /// current user.
+    pub fn new_empty(inode: u64, parent: Option<&Node>) -> Arc<Node> {
+        let now = time::get_time();
 
         let attr = fuse::FileAttr {
             ino: inode,
@@ -57,26 +74,26 @@ impl Dir {
             nlink: 2,  // "." entry plus whichever initial named node points at this.
             size: 2,  // TODO(jmmv): Reevaluate what directory sizes should be.
             blocks: 1,  // TODO(jmmv): Reevaluate what directory blocks should be.
-            atime: time,
-            mtime: time,
-            ctime: time,
-            crtime: time,
+            atime: now,
+            mtime: now,
+            ctime: now,
+            crtime: now,
             perm: 0o555 as u16,  // Scaffold directories cannot be mutated by the user.
-            uid: uid.as_raw(),
-            gid: gid.as_raw(),
+            uid: unistd::getuid().as_raw(),
+            gid: unistd::getgid().as_raw(),
             rdev: 0,
             flags: 0,
         };
 
         let state = MutableDir {
-            parent: inode,
+            parent: parent.map_or(inode, |node| node.inode()),
             underlying_path: None,
             attr: attr,
             children: HashMap::new(),
         };
 
         Arc::new(Dir {
-            inode,
+            inode: inode,
             writable: false,
             state: Mutex::from(state),
         })
@@ -107,6 +124,42 @@ impl Dir {
 
         Arc::new(Dir { inode, writable, state: Mutex::from(state) })
     }
+
+    /// Creates a new scaffold directory as a child of the current one.
+    ///
+    /// Errors are all logged, not reported.  The rationale is that a scaffold directory for an
+    /// intermediate path component of a mapping has to always be created, as it takes preference
+    /// over any other on-disk contents.
+    ///
+    /// This is purely a helper function for `map`.  As a result, the caller is responsible for
+    /// inserting the new directory into the children of the current directory.
+    fn new_scaffold_child(&self, underlying_path: Option<&PathBuf>, name: &OsStr, ids: &IdGenerator)
+        -> Arc<Node> {
+        match underlying_path {
+            Some(path) => {
+                let child_path = path.join(name);
+                match fs::symlink_metadata(&child_path) {
+                    Ok(fs_attr) => {
+                        if fs_attr.is_dir() {
+                            Dir::new_mapped(ids.next(), &child_path, &fs_attr, self.writable)
+                        } else {
+                            info!("Mapping clobbers non-directory {} with an immutable directory",
+                                child_path.display());
+                            Dir::new_empty(ids.next(), Some(self))
+                        }
+                    },
+                    Err(e) => {
+                        if e.kind() != io::ErrorKind::NotFound {
+                            warn!("Mapping clobbers {} due to an IO error: {}",
+                                child_path.display(), e);
+                        }
+                        Dir::new_empty(ids.next(), Some(self))
+                    },
+                }
+            },
+            None => Dir::new_empty(ids.next(), Some(self)),
+        }
+    }
 }
 
 impl Node for Dir {
@@ -116,6 +169,42 @@ impl Node for Dir {
 
     fn writable(&self) -> bool {
         self.writable
+    }
+
+    fn file_type_cached(&self) -> fuse::FileType {
+        fuse::FileType::Directory
+    }
+
+    fn map(&self, components: &[Component], underlying_path: &Path, writable: bool,
+        ids: &IdGenerator, cache: &Cache) -> Result<(), Error> {
+        let (name, remainder) = split_components(components);
+
+        let mut state = self.state.lock().unwrap();
+
+        if let Some(dirent) = state.children.get(name) {
+            // TODO(jmmv): We should probably mark this dirent as an explicit mapping if it already
+            // wasn't, but the Go variant of this code doesn't do this -- so investigate later.
+            ensure!(dirent.node.file_type_cached() == fuse::FileType::Directory, "Already mapped");
+            return dirent.node.map(remainder, underlying_path, writable, ids, cache);
+        }
+
+        let child = if remainder.is_empty() {
+            let fs_attr = fs::symlink_metadata(underlying_path)
+                .context(format!("Stat failed for {:?}", underlying_path))?;
+            cache.get_or_create(ids, underlying_path, &fs_attr, writable)
+        } else {
+            self.new_scaffold_child(state.underlying_path.as_ref(), name, ids)
+        };
+
+        let dirent = Dirent { node: child.clone(), explicit_mapping: true };
+        state.children.insert(name.to_os_string(), dirent);
+
+        if remainder.is_empty() {
+            Ok(())
+        } else {
+            ensure!(child.file_type_cached() == fuse::FileType::Directory, "Already mapped");
+            child.map(remainder, underlying_path, writable, ids, cache)
+        }
     }
 
     fn getattr(&self) -> NodeResult<fuse::FileAttr> {
@@ -144,9 +233,9 @@ impl Node for Dir {
         -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
         let mut state = self.state.lock().unwrap();
 
-        if let Some(node) = state.children.get(name) {
-            let refreshed_attr = node.getattr()?;
-            return Ok((node.clone(), refreshed_attr))
+        if let Some(dirent) = state.children.get(name) {
+            let refreshed_attr = dirent.node.getattr()?;
+            return Ok((dirent.node.clone(), refreshed_attr))
         }
 
         let (child, attr) = {
@@ -159,7 +248,11 @@ impl Node for Dir {
             let attr = conv::attr_fs_to_fuse(path.as_path(), node.inode(), &fs_attr);
             (node, attr)
         };
-        state.children.insert(name.to_os_string(), child.clone());
+        let dirent = Dirent {
+            node: child.clone(),
+            explicit_mapping: false,
+        };
+        state.children.insert(name.to_os_string(), dirent);
         Ok((child, attr))
     }
 
@@ -171,7 +264,12 @@ impl Node for Dir {
         reply.add(state.parent, 1, fuse::FileType::Directory, "..");
         let mut pos = 2;
 
-        // TODO(jmmv): Handle user-provided mappings before underlying entries.
+        for (name, dirent) in &state.children {
+            if dirent.explicit_mapping {
+                reply.add(dirent.node.inode(), pos, dirent.node.file_type_cached(), name);
+                pos += 1;
+            }
+        }
 
         if state.underlying_path.as_ref().is_none() {
             return Ok(());
@@ -181,16 +279,26 @@ impl Node for Dir {
         for entry in entries {
             let entry = entry?;
             let name = entry.file_name();
-            let fs_attr = entry.metadata()?;
+
+            if let Some(dirent) = state.children.get(&name) {
+                if dirent.explicit_mapping {
+                    continue;
+                }
+            }
 
             let path = state.underlying_path.as_ref().unwrap().join(&name);
+            let fs_attr = entry.metadata()?;
+            let fs_type = conv::filetype_fs_to_fuse(&path, fs_attr.file_type());
             let child = cache.get_or_create(ids, &path, &fs_attr, self.writable);
 
-            reply.add(child.inode(), pos,
-                conv::filetype_fs_to_fuse(&path, fs_attr.file_type()), &name);
+            reply.add(child.inode(), pos, fs_type, &name);
             // Do the insertion into state.children after calling reply.add() to be able to move
             // the name into the key without having to copy it again.
-            state.children.insert(name, child.clone());
+            let dirent = Dirent {
+                node: child.clone(),
+                explicit_mapping: false,
+            };
+            state.children.insert(name, dirent);
 
             pos += 1;
         }

--- a/src/nodes/file.rs
+++ b/src/nodes/file.rs
@@ -87,6 +87,11 @@ impl Node for File {
         self.writable
     }
 
+    fn file_type_cached(&self) -> fuse::FileType {
+        let state = self.state.lock().unwrap();
+        state.attr.kind
+    }
+
     fn getattr(&self) -> NodeResult<fuse::FileAttr> {
         let mut state = self.state.lock().unwrap();
 

--- a/src/nodes/symlink.rs
+++ b/src/nodes/symlink.rs
@@ -69,6 +69,10 @@ impl Node for Symlink {
         self.writable
     }
 
+    fn file_type_cached(&self) -> fuse::FileType {
+        fuse::FileType::Symlink
+    }
+
     fn getattr(&self) -> NodeResult<fuse::FileAttr> {
         let mut state = self.state.lock().unwrap();
 


### PR DESCRIPTION
Implement support for when multiple mappings are passed via the command
line.

The diff below is against a bunch of not-yet-merged patches (the `misc` branch), but sending it out already for preliminary review. I'm not super-happy about the `map` algorithm, but attempts to simplify it haven't resulted in much nicer code.