### PR TITLE
Add handles for directories

### DIFF
--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -37,5 +37,6 @@ go_test(
         "//integration/utils:go_default_library",
         "//internal/sandbox:go_default_library",
         "@org_bazil_fuse//:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
     ],
 )


### PR DESCRIPTION
The previous implementation used a single readdir hook to hande reads
from directories but this prevents supporting the case of reading from
an open-but-deleted directory -- which we need to support.

To fix this, add handle tracking to directories and implement separate
opendir/readdir operations for them.

There are integration tests that cover this functionality, but they are
coupled with the presence of setattr.  That's how I discovered that I
had to implement directory handles, but this means that I cannot enable
those tests until setattr lands (next PR).