### PR TITLE
Implement creation of all supported file types

### DIFF
--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -104,7 +104,6 @@ do_rust() {
     TestReadWrite_FchmodOnDeletedNode
     TestReadWrite_FchownOnDeletedNode
     TestReadWrite_FutimesOnDeletedNode
-    TestReadWrite_HardLinksNotSupported
     TestReconfiguration_Streams
     TestReconfiguration_Steps
     TestReconfiguration_Unmap

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -85,7 +85,6 @@ do_rust() {
     TestCli_Syntax
     TestDebug_FuseOpsInLog
     TestLayout_MountPointDoesNotExist
-    TestNesting_ReadWriteWithinReadOnly
     TestOptions_Allow
     TestOptions_Syntax
     TestProfiling_Http
@@ -97,7 +96,6 @@ do_rust() {
     TestReadWrite_FstatOnDeletedNode
     TestReadWrite_FtruncateOnDeletedFile
     TestReadWrite_NestedMappingsInheritDirectoryProperties
-    TestReadWrite_NestedMappingsClobberFiles
     TestReadWrite_RenameFile
     TestReadWrite_MoveFile
     TestReadWrite_Mknod

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -86,17 +86,13 @@ do_rust() {
     TestDebug_FuseOpsInLog
     TestLayout_MountPointDoesNotExist
     TestNesting_ReadWriteWithinReadOnly
-    TestNesting_SameTarget
     TestOptions_Allow
     TestOptions_Syntax
     TestProfiling_Http
     TestProfiling_FileProfiles
     TestProfiling_BadConfiguration
     TestReadOnly_Attributes
-    TestReadWrite_CreateFile
     TestReadWrite_Remove
-    TestReadWrite_RewriteFile
-    TestReadWrite_RewriteFileWithShorterContent
     TestReadWrite_InodeReassignedAfterRecreation
     TestReadWrite_FstatOnDeletedNode
     TestReadWrite_FtruncateOnDeletedFile

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -98,7 +98,6 @@ do_rust() {
     TestReadWrite_NestedMappingsInheritDirectoryProperties
     TestReadWrite_RenameFile
     TestReadWrite_MoveFile
-    TestReadWrite_Mknod
     TestReadWrite_FchmodOnDeletedNode
     TestReadWrite_FchownOnDeletedNode
     TestReadWrite_FutimesOnDeletedNode

--- a/integration/read_write_test.go
+++ b/integration/read_write_test.go
@@ -942,3 +942,23 @@ func TestReadWrite_HardLinksNotSupported(t *testing.T) {
 		})
 	}
 }
+
+func TestReadWrite_SymlinkAndReadlink(t *testing.T) {
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
+	defer state.TearDown(t)
+
+	path := state.MountPath("symlink")
+	target := "some/random/dangling/target"
+
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatalf("Failed to create symlink %s: %v", path, err)
+	}
+
+	gotTarget, err := os.Readlink(path)
+	if err != nil {
+		t.Fatalf("Failed to read symlink %s: %v", path, err)
+	}
+	if target != gotTarget {
+		t.Errorf("Want symlink target to be %s, got %s", target, gotTarget)
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,9 +389,21 @@ impl fuse::Filesystem for SandboxFS {
         }
     }
 
-    fn mkdir(&mut self, _req: &fuse::Request, _parent: u64, _name: &OsStr, _mode: u32,
-        _reply: fuse::ReplyEntry) {
-        panic!("Required RW operation not yet implemented");
+    fn mkdir(&mut self, _req: &fuse::Request, parent: u64, name: &OsStr, mode: u32,
+        reply: fuse::ReplyEntry) {
+        let dir_node = self.find_node(parent);
+        if !dir_node.writable() {
+            reply.error(Errno::EPERM as i32);
+            return;
+        }
+
+        match dir_node.mkdir(name, mode, &self.ids, &self.cache) {
+            Ok((node, attr)) => {
+                self.insert_node(node);
+                reply.entry(&TTL, &attr, IdGenerator::GENERATION);
+            },
+            Err(e) => reply.error(e.errno_as_i32()),
+        }
     }
 
     fn mknod(&mut self, _req: &fuse::Request, _parent: u64, _name: &OsStr, _mode: u32, _rdev: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,8 +368,9 @@ impl fuse::Filesystem for SandboxFS {
     }
 
     fn link(&mut self, _req: &fuse::Request, _inode: u64, _newparent: u64, _newname: &OsStr,
-        _reply: fuse::ReplyEntry) {
-        panic!("Required RW operation not yet implemented");
+        reply: fuse::ReplyEntry) {
+        // We don't support hardlinks at this point.
+        reply.error(Errno::EPERM as i32);
     }
 
     fn lookup(&mut self, _req: &fuse::Request, parent: u64, name: &OsStr, reply: fuse::ReplyEntry) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,7 @@ impl fuse::Filesystem for SandboxFS {
         _bkuptime: Option<Timespec>, _flags: Option<u32>, reply: fuse::ReplyAttr) {
         let node = self.find_node(inode);
         if !node.writable() {
-            reply.error(Errno::EACCES as i32);
+            reply.error(Errno::EPERM as i32);
             return;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,13 @@ pub struct IdGenerator {
 }
 
 impl IdGenerator {
+    /// Generation number to return to the kernel for any inode number.
+    ///
+    /// We don't reuse inode numbers throughout the lifetime of a sandboxfs instance and we do not
+    /// support FUSE daemon restarts without going through an unmount/mount sequence, so it is OK
+    /// to have a constant number here.
+    const GENERATION: u64 = 0;
+
     /// Constructs a new generator that starts at the given value.
     fn new(start_value: u64) -> Self {
         IdGenerator { last_id: AtomicUsize::new(start_value as usize) }
@@ -291,6 +298,21 @@ impl SandboxFS {
         handles.get(&fh).expect("Kernel requested unknown handle").clone()
     }
 
+    /// Tracks a new file handle and assigns an identifier to it.
+    fn insert_handle(&mut self, handle: Arc<nodes::Handle>) -> u64 {
+        let fh = self.ids.next();
+        let mut handles = self.handles.lock().unwrap();
+        debug_assert!(!handles.contains_key(&fh));
+        handles.insert(fh, handle);
+        fh
+    }
+
+    /// Tracks a node, which may already be known.
+    fn insert_node(&mut self, node: Arc<nodes::Node>) {
+        let mut nodes = self.nodes.lock().unwrap();
+        nodes.entry(node.inode()).or_insert(node);
+    }
+
     /// Opens a new handle for the given `inode`.
     ///
     /// This is a helper function to implement the symmetric `open` and `opendir` hooks.
@@ -299,11 +321,7 @@ impl SandboxFS {
 
         match node.open(flags) {
             Ok(handle) => {
-                let fh = self.ids.next();
-                {
-                    let mut handles = self.handles.lock().unwrap();
-                    handles.insert(fh, handle);
-                }
+                let fh = self.insert_handle(handle);
                 reply.opened(fh, flags);
             },
             Err(e) => reply.error(e.errno_as_i32()),
@@ -323,9 +341,22 @@ impl SandboxFS {
 }
 
 impl fuse::Filesystem for SandboxFS {
-    fn create(&mut self, _req: &fuse::Request, _parent: u64, _name: &OsStr, _mode: u32, _flags: u32,
-        _reply: fuse::ReplyCreate) {
-        panic!("Required RW operation not yet implemented");
+    fn create(&mut self, _req: &fuse::Request, parent: u64, name: &OsStr, mode: u32, flags: u32,
+        reply: fuse::ReplyCreate) {
+        let dir_node = self.find_node(parent);
+        if !dir_node.writable() {
+            reply.error(Errno::EPERM as i32);
+            return;
+        }
+
+        match dir_node.create(name, mode, flags, &self.ids, &self.cache) {
+            Ok((node, handle, attr)) => {
+                self.insert_node(node);
+                let fh = self.insert_handle(handle);
+                reply.created(&TTL, &attr, IdGenerator::GENERATION, fh, flags);
+            },
+            Err(e) => reply.error(e.errno_as_i32()),
+        }
     }
 
     fn getattr(&mut self, _req: &fuse::Request, inode: u64, reply: fuse::ReplyAttr) {
@@ -351,7 +382,7 @@ impl fuse::Filesystem for SandboxFS {
                         nodes.insert(node.inode(), node);
                     }
                 }
-                reply.entry(&TTL, &attr, 0);
+                reply.entry(&TTL, &attr, IdGenerator::GENERATION);
             },
             Err(e) => reply.error(e.errno_as_i32()),
         }
@@ -473,6 +504,16 @@ impl fuse::Filesystem for SandboxFS {
     fn unlink(&mut self, _req: &fuse::Request, _parent: u64, _name: &OsStr,
         _reply: fuse::ReplyEmpty) {
         panic!("Required RW operation not yet implemented");
+    }
+
+    fn write(&mut self, _req: &fuse::Request, _inode: u64, fh: u64, offset: i64, data: &[u8],
+        _flags: u32, reply: fuse::ReplyWrite) {
+        let handle = self.find_handle(fh);
+
+        match handle.write(offset, data) {
+            Ok(size) => reply.written(size),
+            Err(e) => reply.error(e.errno_as_i32()),
+        }
     }
 }
 

--- a/src/nodes/file.rs
+++ b/src/nodes/file.rs
@@ -118,7 +118,7 @@ impl Node for File {
         options.read(true);
         if flags & (fcntl::OFlag::O_WRONLY | fcntl::OFlag::O_RDWR).bits() != 0 {
             if !self.writable {
-                return Err(KernelError::from_errno(errno::Errno::EACCES));
+                return Err(KernelError::from_errno(errno::Errno::EPERM));
             }
             if flags & fcntl::OFlag::O_WRONLY.bits() != 0 {
                 options.read(false);

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -258,6 +258,18 @@ pub trait Node {
         panic!("Not implemented")
     }
 
+    /// Creates a new special file with `_name`, `_mode`, and `_rdev`.
+    ///
+    /// The attributes are returned to avoid having to relock the node on the caller side in order
+    /// to supply those attributes to the kernel.
+    ///
+    /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
+    /// nodes, used when create has to instantiate a new node.
+    fn mknod(&self, _name: &OsStr, _mode: u32, _rdev: u32, _ids: &IdGenerator, _cache: &Cache)
+        -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
+        panic!("Not implemented")
+    }
+
     /// Opens the file and returns an open file handle for it.
     fn open(&self, _flags: u32) -> NodeResult<Arc<Handle>> {
         panic!("Not implemented");

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -143,7 +143,7 @@ pub fn setattr(path: &Path, attr: &fuse::FileAttr, delta: &AttrDelta) -> Result<
 
 /// Abstract representation of an open file handle.
 pub trait Handle {
-    /// Reads `size` bytes from the open file starting at `offset`.
+    /// Reads `_size` bytes from the open file starting at `_offset`.
     fn read(&self, _offset: i64, _size: u32) -> NodeResult<Vec<u8>> {
         panic!("Not implemented")
     }
@@ -159,6 +159,11 @@ pub trait Handle {
     /// nodes, used when readdir discovers an underlying node that was not yet known.
     fn readdir(&self, _ids: &IdGenerator, _cache: &Cache, _reply: &mut fuse::ReplyDirectory)
         -> NodeResult<()> {
+        panic!("Not implemented");
+    }
+
+    /// Writes the bytes held in `_data` to the open file starting at `_offset`.
+    fn write(&self, _offset: i64, _data: &[u8]) -> NodeResult<u32> {
         panic!("Not implemented");
     }
 }
@@ -209,6 +214,19 @@ pub trait Node {
     /// nodes, used when this algorithm instantiates any new node.
     fn map(&self, _components: &[Component], _underlying_path: &Path, _writable: bool,
         _ids: &IdGenerator, _cache: &Cache) -> Result<(), Error> {
+        panic!("Not implemented")
+    }
+
+    /// Creates a new file with `_name` and `_mode` and opens it with `_flags`.
+    ///
+    /// The attributes are returned to avoid having to relock the node on the caller side in order
+    /// to supply those attributes to the kernel.
+    ///
+    /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
+    /// nodes, used when create has to instantiate a new node.
+    #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
+    fn create(&self, _name: &OsStr, _mode: u32, _flags: u32, _ids: &IdGenerator, _cache: &Cache)
+        -> NodeResult<(Arc<Node>, Arc<Handle>, fuse::FileAttr)> {
         panic!("Not implemented")
     }
 

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -246,6 +246,18 @@ pub trait Node {
         panic!("Not implemented");
     }
 
+    /// Creates a new directory with `_name` and `_mode`.
+    ///
+    /// The attributes are returned to avoid having to relock the node on the caller side in order
+    /// to supply those attributes to the kernel.
+    ///
+    /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
+    /// nodes, used when create has to instantiate a new node.
+    fn mkdir(&self, _name: &OsStr, _mode: u32, _ids: &IdGenerator, _cache: &Cache)
+        -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
+        panic!("Not implemented")
+    }
+
     /// Opens the file and returns an open file handle for it.
     fn open(&self, _flags: u32) -> NodeResult<Arc<Handle>> {
         panic!("Not implemented");

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -282,4 +282,16 @@ pub trait Node {
 
     /// Sets one or more properties of the node's metadata.
     fn setattr(&self, _delta: &AttrDelta) -> NodeResult<fuse::FileAttr>;
+
+    /// Creates a symlink with `_name` pointing at `_link`.
+    ///
+    /// The attributes are returned to avoid having to relock the node on the caller side in order
+    /// to supply those attributes to the kernel.
+    ///
+    /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
+    /// nodes, used when create has to instantiate a new node.
+    fn symlink(&self, _name: &OsStr, _link: &Path, _ids: &IdGenerator, _cache: &Cache)
+        -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
+        panic!("Not implemented")
+    }
 }


### PR DESCRIPTION
This bag of commits adds support for creating all supported file types within directories.

If the PR is too long I can break it into pieces, but the reason I sent it in one chunk is because most commits are "trivial" once the refactorings that "Implement file creation and file writes" does are put in place.