### PR TITLE
Implement node deletions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rev = "4b23d3962c1baff6483caabf1ca15068216a7506"
 [dependencies.nix]
 # TODO(jmmv): Replace this with 0.12 once released.
 git = "https://github.com/nix-rust/nix.git"
-rev = "eef3a432d57e8f830e05fede6e3099dcb689aa6b"
+rev = "8c3e43ccd4fc83583c16848a35410022f5a8efc9"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,7 +57,7 @@ go_repository(
 go_repository(
     name = "org_golang_x_sys",
     importpath = "golang.org/x/sys",
-    commit = "4b45465282a4624cf39876842a017334f13b8aff",
+    commit = "9b800f95dbbc54abff0acf7ee32d88ba4e328c89",
 )
 
 gazelle_dependencies()

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -91,16 +91,10 @@ do_rust() {
     TestProfiling_FileProfiles
     TestProfiling_BadConfiguration
     TestReadOnly_Attributes
-    TestReadWrite_Remove
     TestReadWrite_InodeReassignedAfterRecreation
-    TestReadWrite_FstatOnDeletedNode
-    TestReadWrite_FtruncateOnDeletedFile
     TestReadWrite_NestedMappingsInheritDirectoryProperties
     TestReadWrite_RenameFile
     TestReadWrite_MoveFile
-    TestReadWrite_FchmodOnDeletedNode
-    TestReadWrite_FchownOnDeletedNode
-    TestReadWrite_FutimesOnDeletedNode
     TestReconfiguration_Streams
     TestReconfiguration_Steps
     TestReconfiguration_Unmap

--- a/internal/sandbox/node.go
+++ b/internal/sandbox/node.go
@@ -342,6 +342,13 @@ func (n *BaseNode) setattrTimes(req *fuse.SetattrRequest) error {
 	}
 
 	if underlyingPath, isMapped := n.UnderlyingPath(); isMapped && !n.deleted {
+		if n.attr.Mode&os.ModeType == os.ModeSymlink {
+			// TODO(https://github.com/bazelbuild/sandboxfs/issues/46): Should use
+			// futimensat to support changing the times of a symlink if requested to
+			// do so.
+			return fuse.Errno(syscall.EOPNOTSUPP)
+		}
+
 		if err := os.Chtimes(underlyingPath, atime, mtime); err != nil {
 			return err
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,13 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+// For portability reasons, we need to be able to cast integer values to system-level opaque
+// types such as "mode_t".  Because we don't know the size of those integers on the platform we
+// are building for, sometimes the casts do widen the values but other times they are no-ops.
+#![cfg_attr(feature = "cargo-clippy", allow(identity_conversion))]
+
+// We construct complex structures in multiple places, and allowing for redundant field names
+// increases readability.
 #![cfg_attr(feature = "cargo-clippy", allow(redundant_field_names))]
 
 #[macro_use] extern crate failure;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,9 +489,17 @@ impl fuse::Filesystem for SandboxFS {
         panic!("Required RW operation not yet implemented");
     }
 
-    fn rmdir(&mut self, _req: &fuse::Request, _parent: u64, _name: &OsStr,
-        _reply: fuse::ReplyEmpty) {
-        panic!("Required RW operation not yet implemented");
+    fn rmdir(&mut self, _req: &fuse::Request, parent: u64, name: &OsStr, reply: fuse::ReplyEmpty) {
+        let dir_node = self.find_node(parent);
+        if !dir_node.writable() {
+            reply.error(Errno::EPERM as i32);
+            return;
+        }
+
+        match dir_node.rmdir(name) {
+            Ok(_) => reply.ok(),
+            Err(e) => reply.error(e.errno_as_i32()),
+        }
     }
 
     fn setattr(&mut self, _req: &fuse::Request, inode: u64, mode: Option<u32>, uid: Option<u32>,
@@ -545,9 +553,17 @@ impl fuse::Filesystem for SandboxFS {
         }
     }
 
-    fn unlink(&mut self, _req: &fuse::Request, _parent: u64, _name: &OsStr,
-        _reply: fuse::ReplyEmpty) {
-        panic!("Required RW operation not yet implemented");
+    fn unlink(&mut self, _req: &fuse::Request, parent: u64, name: &OsStr, reply: fuse::ReplyEmpty) {
+        let dir_node = self.find_node(parent);
+        if !dir_node.writable() {
+            reply.error(Errno::EPERM as i32);
+            return;
+        }
+
+        match dir_node.unlink(name) {
+            Ok(_) => reply.ok(),
+            Err(e) => reply.error(e.errno_as_i32()),
+        }
     }
 
     fn write(&mut self, _req: &fuse::Request, _inode: u64, fh: u64, offset: i64, data: &[u8],

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -254,12 +254,12 @@ impl Dir {
         if let Some(path) = &state.underlying_path {
             let fs_attr = fs::symlink_metadata(path)?;
             if !fs_attr.is_dir() {
-                warn!("Path {:?} backing a directory node is no longer a directory; got {:?}",
-                    path, fs_attr.file_type());
+                warn!("Path {} backing a directory node is no longer a directory; got {:?}",
+                    path.display(), fs_attr.file_type());
                 return Err(KernelError::from_errno(errno::Errno::EIO));
             }
             state.attr = conv::attr_fs_to_fuse(path, inode, &fs_attr);
-        };
+        }
 
         Ok(state.attr)
     }
@@ -348,6 +348,22 @@ impl Dir {
             }
         }
     }
+
+    /// Common implementation for the `rmdir` and `unlink` operations.
+    ///
+    /// The behavior of these operations differs only in the syscall we invoke to delete the
+    /// underlying entry, which is passed in as the `remove` parameter.
+    fn remove_any<R>(&self, name: &OsStr, remove: R) -> NodeResult<()>
+        where R: Fn(&PathBuf) -> io::Result<()> {
+        let mut state = self.state.lock().unwrap();
+        let path = Dir::get_writable_path(&mut state, name)?;
+
+        remove(&path)?;
+
+        state.children[name].node.delete();
+        state.children.remove(name);
+        Ok(())
+    }
 }
 
 impl Node for Dir {
@@ -361,6 +377,14 @@ impl Node for Dir {
 
     fn file_type_cached(&self) -> fuse::FileType {
         fuse::FileType::Directory
+    }
+
+    fn delete(&self) {
+        let mut state = self.state.lock().unwrap();
+        assert!(
+            state.underlying_path.is_some(),
+            "Delete already called or trying to delete an explicit mapping");
+        state.underlying_path = None;
     }
 
     fn map(&self, components: &[Component], underlying_path: &Path, writable: bool,
@@ -494,14 +518,14 @@ impl Node for Dir {
         }))
     }
 
+    fn rmdir(&self, name: &OsStr) -> NodeResult<()> {
+        // TODO(jmmv): Figure out how to remove the redundant closure.
+        #[cfg_attr(feature = "cargo-clippy", allow(redundant_closure))]
+        self.remove_any(name, |p| fs::remove_dir(p))
+    }
+
     fn setattr(&self, delta: &AttrDelta) -> NodeResult<fuse::FileAttr> {
         let mut state = self.state.lock().unwrap();
-
-        // setattr only gets called on writable nodes, which must have an underlying path.  This
-        // assertion will go away when we have the ability to delete nodes as those may still
-        // exist in memory but have no corresponding underlying path.
-        debug_assert!(state.underlying_path.is_some());
-
         state.attr = setattr(state.underlying_path.as_ref(), &state.attr, delta)?;
         Ok(state.attr)
     }
@@ -514,5 +538,11 @@ impl Node for Dir {
         unix_fs::symlink(link, &path)?;
         Dir::post_create_lookup(self.writable, &mut state, &path, name,
             fuse::FileType::Symlink, ids, cache)
+    }
+
+    fn unlink(&self, name: &OsStr) -> NodeResult<()> {
+        // TODO(jmmv): Figure out how to remove the redundant closure.
+        #[cfg_attr(feature = "cargo-clippy", allow(redundant_closure))]
+        self.remove_any(name, |p| fs::remove_file(p))
     }
 }

--- a/src/nodes/file.rs
+++ b/src/nodes/file.rs
@@ -135,7 +135,7 @@ impl Node for File {
 
     fn setattr(&self, delta: &AttrDelta) -> NodeResult<fuse::FileAttr> {
         let mut state = self.state.lock().unwrap();
-        setattr(&state.underlying_path, &state.attr, delta)?;
-        File::getattr_locked(self.inode, &mut state)
+        state.attr = setattr(Some(&state.underlying_path), &state.attr, delta)?;
+        Ok(state.attr)
     }
 }

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -289,6 +289,12 @@ pub trait Node {
     /// `Symlink`s (on which we don't allow type changes at all), it's OK.
     fn file_type_cached(&self) -> fuse::FileType;
 
+    /// Marks the node as deleted (though the in-memory representation remains).
+    ///
+    /// The implication of this is that a node loses its backing underlying path once this method
+    /// is called.
+    fn delete(&self);
+
     /// Maps a path onto a node and creates intermediate components as immutable directories.
     ///
     /// `_components` is the path to map, broken down into components, and relative to the current
@@ -365,6 +371,11 @@ pub trait Node {
         panic!("Not implemented");
     }
 
+    /// Deletes the empty directory `_name`.
+    fn rmdir(&self, _name: &OsStr) -> NodeResult<()> {
+        panic!("Not implemented");
+    }
+
     /// Sets one or more properties of the node's metadata.
     fn setattr(&self, _delta: &AttrDelta) -> NodeResult<fuse::FileAttr>;
 
@@ -378,5 +389,10 @@ pub trait Node {
     fn symlink(&self, _name: &OsStr, _link: &Path, _ids: &IdGenerator, _cache: &Cache)
         -> NodeResult<(Arc<Node>, fuse::FileAttr)> {
         panic!("Not implemented")
+    }
+
+    /// Deletes the file `_name`.
+    fn unlink(&self, _name: &OsStr) -> NodeResult<()> {
+        panic!("Not implemented");
     }
 }

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -88,57 +88,142 @@ pub struct AttrDelta {
 /// Generic result type for of all node operations.
 pub type NodeResult<T> = Result<T, KernelError>;
 
+/// Applies an operation to a path if present, or otherwise returns Ok.
+fn try_path<O: Fn(&PathBuf) -> nix::Result<()>>(path: Option<&PathBuf>, op: O) -> nix::Result<()> {
+    match path {
+        Some(path) => op(path),
+        None => Ok(()),
+    }
+}
+
+/// Helper function for `setattr` to apply only the mode changes.
+fn setattr_mode(attr: &mut fuse::FileAttr, path: Option<&PathBuf>, mode: Option<sys::stat::Mode>)
+    -> Result<(), nix::Error> {
+    if mode.is_none() {
+        return Ok(())
+    }
+    let mode = mode.unwrap();
+
+    if mode.bits() > sys::stat::mode_t::from(std::u16::MAX) {
+        warn!("Got setattr with mode {:?} for {:?} (inode {}), which is too large; ignoring",
+            mode, path, attr.ino);
+        return Err(nix::Error::from_errno(Errno::EIO));
+    }
+    let perm = mode.bits() as u16;
+
+    let result = try_path(path, |p|
+        sys::stat::fchmodat(None, p, mode, sys::stat::FchmodatFlags::NoFollowSymlink));
+    if result.is_ok() {
+        attr.perm = perm;
+    }
+    result
+}
+
+/// Helper function for `setattr` to apply only the UID and GID changes.
+fn setattr_owners(attr: &mut fuse::FileAttr, path: Option<&PathBuf>, uid: Option<unistd::Uid>,
+    gid: Option<unistd::Gid>) -> Result<(), nix::Error> {
+    if uid.is_none() && gid.is_none() {
+        return Ok(())
+    }
+
+    let result = try_path(path, |p|
+        unistd::fchownat(None, p, uid, gid, unistd::FchownatFlags::NoFollowSymlink));
+    if result.is_ok() {
+        attr.uid = uid.map_or(attr.uid, u32::from);
+        attr.gid = uid.map_or(attr.gid, u32::from);
+    }
+    result
+}
+
+/// Helper function for `setattr` to apply only the atime and mtime changes.
+fn setattr_times(attr: &mut fuse::FileAttr, path: Option<&PathBuf>,
+    atime: Option<sys::time::TimeVal>, mtime: Option<sys::time::TimeVal>)
+    -> Result<(), nix::Error> {
+    if atime.is_none() && mtime.is_none() {
+        return Ok(());
+    }
+
+    let atime = atime.unwrap_or_else(|| conv::timespec_to_timeval(attr.atime));
+    let mtime = mtime.unwrap_or_else(|| conv::timespec_to_timeval(attr.mtime));
+    if attr.kind == fuse::FileType::Symlink {
+        // TODO(jmmv): Should use futimensat to avoid following symlinks but this function is
+        // not available on macOS El Capitan, which we currently require for CI builds.
+        warn!("Asked to update atime/mtime for symlink {:?} but following symlink instead", path);
+    }
+    let result = try_path(path, |p| sys::stat::utimes(p, &atime, &mtime));
+    if result.is_ok() {
+        attr.atime = conv::timeval_to_timespec(atime);
+        attr.mtime = conv::timeval_to_timespec(mtime);
+    }
+    result
+}
+
+/// Helper function for `setattr` to apply only the size changes.
+fn setattr_size(attr: &mut fuse::FileAttr, path: Option<&PathBuf>, size: Option<u64>)
+    -> Result<(), nix::Error> {
+    if size.is_none() {
+        return Ok(());
+    }
+    let size = size.unwrap();
+
+    let result = if size > ::std::i64::MAX as u64 {
+        warn!("truncate request got size {}, which is too large (exceeds i64's MAX)", size);
+        Err(nix::Error::invalid_argument())
+    } else {
+        try_path(path, |p| unistd::truncate(p, size as i64))
+    };
+    if result.is_ok() {
+        attr.size = size;
+    }
+    result
+}
+
 /// Updates the metadata of a file given a delta of attributes.
 ///
-/// This is a helper function to implement `Node::setattr` for the various node types.  The caller
-/// is responsible for obtaining the updated metadata of the underlying file to return it to the
-/// kernel, as computing the updated metadata here would be inaccurate.  The reason is that we don't
-/// track ctimes ourselves so any modifications to the file cause the backing ctime to be updated
-/// and we need to obtain it.
-/// TODO(https://github.com/bazelbuild/sandboxfs/issues/43): Compute the modified fuse::FileAttr and
-/// return it once we track ctimes.
+/// This is a helper function to implement `Node::setattr` for the various node types.
 ///
 /// This tries to apply as many properties as possible in case of errors.  When errors occur,
 /// returns the first that was encountered.
-pub fn setattr(path: &Path, attr: &fuse::FileAttr, delta: &AttrDelta) -> Result<(), nix::Error> {
-    let mut result = Ok(());
-
-    if let Some(mode) = delta.mode {
-        result = result.and(
-            sys::stat::fchmodat(None, path, mode, sys::stat::FchmodatFlags::NoFollowSymlink));
-    }
-
-    if delta.uid.is_some() || delta.gid.is_some() {
-        result = result.and(
-            unistd::fchownat(None, path, delta.uid, delta.gid,
-                unistd::FchownatFlags::NoFollowSymlink));
-    }
-
-    if delta.atime.is_some() || delta.mtime.is_some() {
-        let atime = delta.atime.unwrap_or_else(|| conv::timespec_to_timeval(attr.atime));
-        let mtime = delta.mtime.unwrap_or_else(|| conv::timespec_to_timeval(attr.mtime));
-        if attr.kind == fuse::FileType::Symlink {
-            // TODO(jmmv): Should use futimensat to avoid following symlinks but this function is
-            // not available on macOS El Capitan, which we currently require for CI builds.
-            warn!("Asked to update atime/mtime for symlink {} but following symlink instead",
-                path.display());
+pub fn setattr(path: Option<&PathBuf>, attr: &fuse::FileAttr, delta: &AttrDelta)
+    -> Result<fuse::FileAttr, nix::Error> {
+    // Compute the potential new ctime for these updates.  We want to avoid picking a ctime that is
+    // larger than what the operations below can result in (so as to prevent a future getattr from
+    // moving the ctime back) which is tricky because we don't know the time resolution of the
+    // underlying file system.  Some, like HFS+, only have 1-second resolution... so pick that in
+    // the worst case.
+    //
+    // This is not perfectly accurate because we don't actually know what ctime the underlying file
+    // has gotten and thus a future getattr on it will cause the ctime to change.  But as long as we
+    // avoid going back on time, we can afford to do this -- which is a requirement for supporting
+    // setting attributes on deleted files.
+    //
+    // TODO(https://github.com/bazelbuild/sandboxfs/issues/43): Revisit this when we track
+    // ctimes purely on our own.
+    let updated_ctime = {
+        let mut now = time::now().to_timespec();
+        now.nsec = 0;
+        if attr.ctime > now {
+            attr.ctime
+        } else {
+            now
         }
-        result = result.and(sys::stat::utimes(path, &atime, &mtime));
-    }
+    };
 
-    if let Some(size) = delta.size {
+    let mut new_attr = *attr;
+    // Intentionally using and() instead of and_then() to try to apply all changes but to only
+    // keep the first error result.
+    let result = Ok(())
+        .and(setattr_mode(&mut new_attr, path, delta.mode))
+        .and(setattr_owners(&mut new_attr, path, delta.uid, delta.gid))
+        .and(setattr_times(&mut new_attr, path, delta.atime, delta.mtime))
         // Updating the size only makes sense on files, but handling it here is much simpler than
         // doing so on a node type basis.  Plus, who knows, if the kernel asked us to change the
         // size of anything other than a file, maybe we have to obey and try to do it.
-        if size > ::std::i64::MAX as u64 {
-            warn!("truncate request got size {}, which is too large (exceeds i64's MAX)", size);
-            result = result.and(Err(nix::Error::invalid_argument()));
-        } else {
-            result = result.and(unistd::truncate(path, size as i64));
-        }
+        .and(setattr_size(&mut new_attr, path, delta.size));
+    if *attr != new_attr {
+        new_attr.ctime = updated_ctime;
     }
-
-    result
+    result.and(Ok(new_attr))
 }
 
 /// Abstract representation of an open file handle.

--- a/src/nodes/symlink.rs
+++ b/src/nodes/symlink.rs
@@ -99,7 +99,7 @@ impl Node for Symlink {
 
     fn setattr(&self, delta: &AttrDelta) -> NodeResult<fuse::FileAttr> {
         let mut state = self.state.lock().unwrap();
-        setattr(&state.underlying_path, &state.attr, delta)?;
-        Symlink::getattr_locked(self.inode, &mut state)
+        state.attr = setattr(Some(&state.underlying_path), &state.attr, delta)?;
+        Ok(state.attr)
     }
 }


### PR DESCRIPTION
This PR is a complex because of all the required refactoring of `setattr`, but the implementation of the actual unlinking operations is pretty simple once that is done. Let me know if you want me to send the two commits separately for review.

Also, I've left a couple of TODOs in place because I just can't figure out what the type of the lambda should be. Clippy implies that I can remove the redundant closure, but that's not true.

And... we are almost feature complete! The most significant thing left is the ability to apply reconfigurations.

Thanks