### PR TITLE
Make the TTL of file metadata configurable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,9 @@ fn parse_duration(s: &str) -> Result<Timespec, UsageError> {
     };
 
     if unit != SECONDS_SUFFIX {
-        let message = format!("invalid time specification {}: unsupported unit '{}'", s, unit);
+        let message = format!(
+            "invalid time specification {}: unsupported unit '{}' (only '{}' is allowed)",
+            s, unit, SECONDS_SUFFIX);
         return Err(UsageError { message });
     }
 


### PR DESCRIPTION
Add a new --ttl flag to let the user of sandboxfs configure how long
to cache file metadata for in the kernel before the kernel decides to
query the user-space daemon again.

This feature will come in handy when implementing reconfigurations
because we won't be able to implement unmaps with correct semantics
just yet: the FUSE bindings we use do not support kernel invalidations
so we will tell the user to adjust the TTL instead.  (I want to add
the missing feature to the FUSE bindings... but it's not a trivial
effort.)

Note that this feature is not a hack per se: exposing the TTL value
to the user as a configuration setting is worthwhile and so this is
here to stay.