### PR TITLE
Implement termination signal handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,14 @@ env_logger = "0.5"
 failure = "~0.1.2"
 getopts = "0.2"
 log = "0.4"
+signal-hook = "0.1"
 time = "0.1"
 
 [dependencies.fuse]
-# TODO(jmmv): Replace this with 0.4 once released.
-git = "https://github.com/zargony/rust-fuse.git"
-rev = "4b23d3962c1baff6483caabf1ca15068216a7506"
+# TODO(jmmv): Replace this with 0.4 or an upstream commit once
+# https://github.com/zargony/rust-fuse/pull/119 is merged.
+git = "https://github.com/jmmv/rust-fuse.git"
+rev = "07c47e9cc311a0d2890785d7a4098b76cb33a2ad"
 
 [dependencies.nix]
 # TODO(jmmv): Replace this with 0.12 once released.

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -106,9 +106,6 @@ do_rust() {
     TestReconfiguration_WritableNodesAreDifferent
     TestReconfiguration_FileSystemStillWorksAfterInputEOF
     TestReconfiguration_StreamFileDoesNotExist
-    TestSignal_RaceBetweenSignalSetupAndMount
-    TestSignal_UnmountWhenCaught
-    TestSignal_QueuedWhileInUse
   )
 
   # TODO(https://github.com/bazelbuild/rules_rust/issues/2): Replace by a

--- a/cmd/sandboxfs/sandboxfs.go
+++ b/cmd/sandboxfs/sandboxfs.go
@@ -65,7 +65,7 @@ var (
 // handling at some point so maybe we'll be able to revisit this in the future? Who knows.
 func handleSignals(mountPoint <-chan string, caughtSignal chan<- os.Signal) {
 	handler := make(chan os.Signal, 1)
-	signal.Notify(handler, syscall.SIGHUP, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(handler, syscall.SIGHUP, os.Interrupt, syscall.SIGQUIT, syscall.SIGTERM)
 
 	go func() {
 		caughtSignal <- <-handler // Wait for the signal.

--- a/integration/signal_test.go
+++ b/integration/signal_test.go
@@ -70,7 +70,7 @@ func TestSignal_RaceBetweenSignalSetupAndMount(t *testing.T) {
 }
 
 func TestSignal_UnmountWhenCaught(t *testing.T) {
-	for _, signal := range []os.Signal{syscall.SIGHUP, os.Interrupt, syscall.SIGTERM} {
+	for _, signal := range []os.Signal{syscall.SIGHUP, os.Interrupt, syscall.SIGQUIT, syscall.SIGTERM} {
 		t.Run(signal.String(), func(t *testing.T) {
 			stderr := new(bytes.Buffer)
 

--- a/src/concurrent.rs
+++ b/src/concurrent.rs
@@ -12,12 +12,20 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+use failure::Error;
 use nix::unistd;
+use nix::sys::signal;
+use signal_hook;
+use std::cmp;
 use std::fs;
-use std::io;
+use std::io::{self, Read};
 use std::os::unix::io as unix_io;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::time;
+use std::thread;
 
 /// A file with a single scoped owner but with multiple non-owner views.
 ///
@@ -28,6 +36,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// file handle.  Such views must accept the fact that the handle can be closed at any time, a
 /// condition that is simply exposed as if the handle reached EOF.  Concurrent views can safely be
 /// moved across threads.
+#[allow(unused)]  // TODO(jmmv): Remove once we use this code for reconfigurations.
 pub struct ShareableFile {
     /// Underlying file descriptor shared across all views of this file.
     fd: unix_io::RawFd,
@@ -47,6 +56,7 @@ pub struct ShareableFile {
 
 impl ShareableFile {
     /// Constructs a new `ShareableFile` from an open file and takes ownership of it.
+    #[allow(unused)]  // TODO(jmmv): Remove once we use this code for reconfigurations.
     pub fn from(file: fs::File) -> ShareableFile {
         use std::os::unix::io::IntoRawFd;
         ShareableFile {
@@ -59,6 +69,7 @@ impl ShareableFile {
     /// Returns an unowned view of the file.
     ///
     /// Users of this file must accept that the file can be closed at any time by the owner.
+    #[allow(unused)]  // TODO(jmmv): Remove once we use this code for reconfigurations.
     pub fn clone_unowned(&mut self) -> ShareableFile {
         ShareableFile {
             fd: self.fd,
@@ -86,7 +97,7 @@ impl Drop for ShareableFile {
     }
 }
 
-impl io::Read for ShareableFile {
+impl Read for ShareableFile {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match unistd::read(self.fd, buf) {
             Ok(n) => Ok(n),
@@ -100,6 +111,148 @@ impl io::Read for ShareableFile {
             Err(e) => panic!(
                 "Did not expect to get an error without an errno from a nix call: {:?}", e),
         }
+    }
+}
+
+/// List of termination signals that cause the mount point to be correctly unmounted.
+static CAPTURED_SIGNALS: [signal::Signal; 4] = [
+    signal::Signal::SIGHUP,
+    signal::Signal::SIGTERM,
+    signal::Signal::SIGINT,
+    signal::Signal::SIGQUIT,
+];
+
+/// Two-phase installer for `SignalsHandler`, which is responsible for unmounting a file system.
+///
+/// Installing the signals is tricky business because of a potential race: if the signal handler is
+/// installed and a signal arrives *before* the mount point has been configured, the unmounting will
+/// not succeed, which means we will enter the server loop and lose the signal.  Conversely, if we
+/// did this backwards, we could receive a signal after the mount point has been configured but
+/// before we install the signal handler, which means we'd terminate but leak the mount point.
+///
+/// To solve this, we must block signals while the mount point is being set up.  We achieve this by
+/// exposing an interface that forces the caller to take two steps before it can obtain the actual
+/// `SignalsHandler` object: the caller must call `prepare()` before mounting the file system and
+/// then call `install()` once the file system is ready to serve.
+///
+/// Keeping this logic as a separate `SignalsInstaller` object, instead of trying to expose a "safe
+/// mount function" helps ensure restoration of the original signal mask in all cases because this
+/// type does so at drop time.
+pub struct SignalsInstaller {
+    /// Signal mask to restore at drop time.
+    old_sigset: signal::SigSet,
+}
+
+impl SignalsInstaller {
+    /// Blocks signals in preparation to mount the file system.
+    pub fn prepare() -> SignalsInstaller {
+        let mut old_sigset = signal::SigSet::empty();
+        let mut sigset = signal::SigSet::empty();
+        for signal in CAPTURED_SIGNALS.iter() {
+            sigset.add(*signal);
+        }
+        signal::pthread_sigmask(
+            signal::SigmaskHow::SIG_BLOCK, Some(&sigset), Some(&mut old_sigset))
+            .expect("pthread_sigmask is not expected to fail");
+        SignalsInstaller { old_sigset }
+    }
+
+    /// Installs all signal handlers to unmount the given `mount_point`.
+    pub fn install(self, mount_point: PathBuf) -> Result<SignalsHandler, Error> {
+        let (signal_sender, signal_receiver) = mpsc::channel();
+
+        let mut signums = vec!();
+        for signal in CAPTURED_SIGNALS.iter() {
+            signums.push(*signal as i32);
+        }
+        let signals = signal_hook::iterator::Signals::new(&signums)?;
+
+        std::thread::spawn(move || SignalsHandler::handler(&signals, mount_point, &signal_sender));
+
+        Ok(SignalsHandler { signal_receiver })
+
+        // Consumes self which causes the original signal mask to be restored and thus unblocks
+        // signals.
+    }
+}
+
+impl Drop for SignalsInstaller {
+    fn drop(&mut self) -> () {
+        signal::pthread_sigmask(signal::SigmaskHow::SIG_SETMASK, Some(&self.old_sigset), None)
+            .expect("pthread_sigmask is not expected to fail and we cannot correctly clean up");
+    }
+}
+
+/// Tries to unmount the given file system indefinitely.
+///
+/// If unmounting fails, it is probably because the file system is busy.  We don't know but it
+/// doesn't matter: we have entered a terminal status: we do this at exit time so we'll keep trying
+/// to unclog things while telling the user what's going on.  They are the ones that have to fix
+/// this situation.
+fn retry_unmount<P: AsRef<Path>>(mount_point: P) {
+    let mut backoff = time::Duration::from_millis(10);
+    let goal = time::Duration::from_secs(1);
+    'retry: loop {
+        match fuse::unmount(mount_point.as_ref()) {
+            Ok(()) => break 'retry,
+            Err(e) => {
+                if backoff >= goal {
+                    warn!("Unmounting file system failed with error '{}'; will retry in {:?}",
+                        e, backoff);
+                }
+                thread::sleep(backoff);
+                if backoff < goal {
+                    backoff = cmp::min(goal, backoff * 2);
+                }
+            },
+        }
+    }
+}
+
+/// Maintains state and allows interaction with the installed signal handler.
+///
+/// The signal handler is responsible for unmounting the file system, which in turn causes the
+/// FUSE serve loop to either never start or to finish execution if it was already running.
+pub struct SignalsHandler {
+    /// Channel used to receive, on the main thread, the number of the signal that was captured.
+    // TODO(https://github.com/vorner/signal-hook/pull/8): Replace i32 with SigNo once merged.
+    signal_receiver: mpsc::Receiver<i32>,
+}
+
+impl SignalsHandler {
+    /// Returns the signal that was caught, if any.
+    ///
+    /// This is *not* racy when used after the file system has been unmounted (i.e. once the FUSE
+    /// loop terminates).
+    pub fn caught(&self) -> Option<i32> {
+        match self.signal_receiver.try_recv() {
+            Ok(signo) => Some(signo),
+            Err(_) => None,
+        }
+    }
+
+    /// The signal handler.
+    ///
+    /// This blocks until the receipt of the first signal and then ignores the rest.
+    ///
+    /// Upon receipt of a signal from `signals`, the handler first updates `signal_sender` with the
+    /// number of the received signal and then attempts to unmount `mount_point` indefinitely to
+    /// unblock the main FUSE loop.
+    fn handler(signals: &signal_hook::iterator::Signals, mount_point: PathBuf,
+        signal_sender: &mpsc::Sender<i32>) -> () {
+        let signo = signals.forever().next().unwrap();
+        if let Err(e) = signal_sender.send(signo) {
+            warn!("Failed to propagate signal to main thread; will get stuck exiting: {}", e);
+        }
+        info!("Caught signal {}; unmounting {}", signo, mount_point.display());
+        retry_unmount(mount_point);
+
+        // It'd be nice if we could just "drop(signals)" here and then send the same received signal
+        // to ourselves so that the program terminated with the correct exit status.  Unfortunately,
+        // "drop(signals)" unregisters our hooks from the signal handlers installed by signal-hook
+        // but it does not actually return the signal handlers to their original values.  This is a
+        // limitation of the signal-hook crate.  Instead, we need the "caught" hack above to let the
+        // main thread return an error code instead.
     }
 }
 


### PR DESCRIPTION
Upon receiving a termination signal, sandboxfs should unmount the file
system instead of abruptly exiting and leaving the mount point behind
in an unusable state.  Do so now.

At first I cloned the exact implementation of the Go variant, using the
same message-passing structure between the main program and the thread
handling the signals.  This worked fine but then realized (thanks to a
"note" in the original code!) that we can do better in Rust because of
the ability to control the signal mask via the nix crate.

Note, however, that the way signals are handled may still seem odd in
cases (like e.g. ignoring all signals after the first one is received).
This is intentional to keep the behavior in sync with the Go code and
with what is currently tested.