### PR TITLE
Appease new Clippy warnings

### DIFF
--- a/src/concurrent.rs
+++ b/src/concurrent.rs
@@ -89,7 +89,7 @@ impl ShareableFile {
 }
 
 impl Drop for ShareableFile {
-    fn drop(&mut self) -> () {
+    fn drop(&mut self) {
         debug!("Closing ShareableFile with fd {}", self.fd);
 
         // We are about to touch file handles used by other threads.  If those threads are blocked
@@ -133,7 +133,7 @@ pub struct ShareableFileReader {
 }
 
 impl Drop for ShareableFileReader {
-    fn drop(&mut self) -> () {
+    fn drop(&mut self) {
         if let Err(e) = unistd::close(self.notifier) {
             warn!("Failed to close fd {}: {}", self.notifier, e);
         }
@@ -235,7 +235,7 @@ impl SignalsInstaller {
 }
 
 impl Drop for SignalsInstaller {
-    fn drop(&mut self) -> () {
+    fn drop(&mut self) {
         signal::pthread_sigmask(signal::SigmaskHow::SIG_SETMASK, Some(&self.old_sigset), None)
             .expect("pthread_sigmask is not expected to fail and we cannot correctly clean up");
     }
@@ -297,7 +297,7 @@ impl SignalsHandler {
     /// number of the received signal and then attempts to unmount `mount_point` indefinitely to
     /// unblock the main FUSE loop.
     fn handler(signals: &signal_hook::iterator::Signals, mount_point: PathBuf,
-        signal_sender: &mpsc::Sender<i32>) -> () {
+        signal_sender: &mpsc::Sender<i32>) {
         let signo = signals.forever().next().unwrap();
         if let Err(e) = signal_sender.send(signo) {
             warn!("Failed to propagate signal to main thread; will get stuck exiting: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn parse_mappings<T: AsRef<str>, U: IntoIterator<Item=T>>(args: U)
         let path = PathBuf::from(fields[1]);
         let underlying_path = PathBuf::from(fields[2]);
 
-        match sandboxfs::Mapping::new(path, underlying_path, writable) {
+        match sandboxfs::Mapping::from_parts(path, underlying_path, writable) {
             Ok(mapping) => mappings.push(mapping),
             Err(e) => {
                 // TODO(jmmv): Figure how to best leverage failure's cause propagation.  May need
@@ -244,8 +244,8 @@ mod tests {
     fn test_parse_mappings_ok() {
         let args = ["ro:/:/fake/root", "rw:/foo:/bar"];
         let exp_mappings = vec!(
-            Mapping::new(PathBuf::from("/"), PathBuf::from("/fake/root"), false).unwrap(),
-            Mapping::new(PathBuf::from("/foo"), PathBuf::from("/bar"), true).unwrap(),
+            Mapping::from_parts(PathBuf::from("/"), PathBuf::from("/fake/root"), false).unwrap(),
+            Mapping::from_parts(PathBuf::from("/foo"), PathBuf::from("/bar"), true).unwrap(),
         );
         match parse_mappings(&args) {
             Ok(mappings) => assert_eq!(exp_mappings, mappings),

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -419,7 +419,7 @@ impl Node for Dir {
         }
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
+    #[allow(clippy::type_complexity)]
     fn create(&self, name: &OsStr, mode: u32, flags: u32, ids: &IdGenerator, cache: &Cache)
         -> NodeResult<(ArcNode, ArcHandle, fuse::FileAttr)> {
         let mut state = self.state.lock().unwrap();
@@ -492,7 +492,7 @@ impl Node for Dir {
             },
         };
 
-        #[cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
+        #[allow(clippy::cast_lossless)]
         sys::stat::mknod(&path, sflag, perm, rdev as sys::stat::dev_t)?;
         Dir::post_create_lookup(self.writable, &mut state, &path, name, exp_filetype, ids, cache)
     }
@@ -520,7 +520,7 @@ impl Node for Dir {
 
     fn rmdir(&self, name: &OsStr) -> NodeResult<()> {
         // TODO(jmmv): Figure out how to remove the redundant closure.
-        #[cfg_attr(feature = "cargo-clippy", allow(redundant_closure))]
+        #[allow(clippy::redundant_closure)]
         self.remove_any(name, |p| fs::remove_dir(p))
     }
 
@@ -542,7 +542,7 @@ impl Node for Dir {
 
     fn unlink(&self, name: &OsStr) -> NodeResult<()> {
         // TODO(jmmv): Figure out how to remove the redundant closure.
-        #[cfg_attr(feature = "cargo-clippy", allow(redundant_closure))]
+        #[allow(clippy::redundant_closure)]
         self.remove_any(name, |p| fs::remove_file(p))
     }
 }

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -319,7 +319,7 @@ pub trait Node {
     ///
     /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
     /// nodes, used when create has to instantiate a new node.
-    #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
+    #[allow(clippy::type_complexity)]
     fn create(&self, _name: &OsStr, _mode: u32, _flags: u32, _ids: &IdGenerator, _cache: &Cache)
         -> NodeResult<(ArcNode, ArcHandle, fuse::FileAttr)> {
         panic!("Not implemented")


### PR DESCRIPTION
With the most recent release of Clippy, our CI builds broke because they
caught new issues in the code.  Address those now so that we can unblock
other PRs.