### PR TITLE
Implement renames and moves

### DIFF
--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -93,6 +93,7 @@ do_rust() {
     TestReadWrite_NestedMappingsInheritDirectoryProperties
     TestReadWrite_RenameFile
     TestReadWrite_MoveFile
+    TestReadWrite_MoveRace
     TestReconfiguration_Streams
     TestReconfiguration_Steps
     TestReconfiguration_Unmap

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -91,9 +91,6 @@ do_rust() {
     TestReadOnly_Attributes
     TestReadWrite_InodeReassignedAfterRecreation
     TestReadWrite_NestedMappingsInheritDirectoryProperties
-    TestReadWrite_RenameFile
-    TestReadWrite_MoveFile
-    TestReadWrite_MoveRace
     TestReconfiguration_Streams
     TestReconfiguration_Steps
     TestReconfiguration_Unmap

--- a/src/nodes/file.rs
+++ b/src/nodes/file.rs
@@ -129,6 +129,13 @@ impl Node for File {
         state.underlying_path = None;
     }
 
+    fn set_underlying_path(&self, path: &Path) {
+        let mut state = self.state.lock().unwrap();
+        debug_assert!(state.underlying_path.is_some(),
+            "Renames should not have been allowed in scaffold or deleted nodes");
+        state.underlying_path = Some(PathBuf::from(path));
+    }
+
     fn getattr(&self) -> NodeResult<fuse::FileAttr> {
         let mut state = self.state.lock().unwrap();
         File::getattr_locked(self.inode, &mut state)

--- a/src/nodes/symlink.rs
+++ b/src/nodes/symlink.rs
@@ -95,6 +95,13 @@ impl Node for Symlink {
         state.underlying_path = None;
     }
 
+    fn set_underlying_path(&self, path: &Path) {
+        let mut state = self.state.lock().unwrap();
+        debug_assert!(state.underlying_path.is_some(),
+            "Renames should not have been allowed in scaffold or deleted nodes");
+        state.underlying_path = Some(PathBuf::from(path));
+    }
+
     fn getattr(&self) -> NodeResult<fuse::FileAttr> {
         let mut state = self.state.lock().unwrap();
         Symlink::getattr_locked(self.inode, &mut state)


### PR DESCRIPTION
Oops. I completely forgot about implementing this operation. I am not too happy with the current code (especially because of handling moves and renames separately), but I wasn't either with the Go variant due to its introspection of types. Trying a different approach.

----- Commit message -----

Handling renames within a single directory is easy, but supporting a move
across directories is difficult because we need to lock two nodes and it
is good to not leak the implications of this through the Node trait.

To support the latter case, I have split the rename operation in two: one
for the responsibilities of the source node and one for the target node.
This approach allows keeping the Node interface and the Dir type
oblivious to the various Node types that exist (i.e. we don't need
introspection as the Go variant of this code needed).  The downside is
that the need for the source/target method split looks strange, and in
the source side, we have to support "rolling back" a failed move.
Having seen the two possible implementations, I think this is clearer.