### PR TITLE
Add support for the --allow flag

### DIFF
--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -85,8 +85,6 @@ do_rust() {
     TestCli_Syntax
     TestDebug_FuseOpsInLog
     TestLayout_MountPointDoesNotExist
-    TestOptions_Allow
-    TestOptions_Syntax
     TestProfiling_Http
     TestProfiling_FileProfiles
     TestProfiling_BadConfiguration


### PR DESCRIPTION
This controls whether allow_other or allow_root are passed to the FUSE
mount operation.  The interface of this flag mimics the one in the Go
variant of this code.