### PR TITLE
Upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,8 @@ language:
   - java  # For Bazel.
 
 go:
-  - "1.8"
-  - "1.9"
   - "1.10"
+  - "1.11"
 go_import_path: github.com/bazelbuild/sandboxfs
 
 env:
@@ -47,30 +46,25 @@ script: ./admin/travis-build.sh
 
 matrix:
   exclude:
-    # For Go 1.8 and 1.9, we are only interested in testing that our code builds
+    # For Go 1.10, we are only interested in testing that our code builds
     # correctly under that version of the language.  A single test is sufficient
     # for this, so remove all other configurations.
     - env: DO=gotools
-      go: "1.8"
+      go: "1.10"
     - env: DO=gotools
-      go: "1.9"
-    - go: "1.8"
+      go: "1.10"
       os: osx
-    - go: "1.9"
+    - go: "1.10"
       os: osx
 
     # For code linting, we just need to run this under a single configuration.
     # Trim all but one, and prefer Linux over macOS because it's much faster.
     - env: DO=lint
-      go: "1.8"
-    - env: DO=lint
-      go: "1.9"
+      go: "1.10"
     - env: DO=lint
       os: osx
 
     # For testing the Rust implementation, we only need to build the tests using
     # one Go version.
     - env: DO=rust
-      go: "1.8"
-    - env: DO=rust
-      go: "1.9"
+      go: "1.10"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,7 @@
 licenses(["notice"])  # Apache License 2.0
 
+# gazelle:resolve go github.com/bazelbuild/rules_go/go/tools/bazel @io_bazel_rules_go//go/tools/bazel:go_default_library
+
 exports_files(["WORKSPACE"])
 
 exports_files(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,40 +1,58 @@
 workspace(name = "sandboxfs")
 
-http_archive(
-    name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.9.0/rules_go-0.9.0.tar.gz",
-    sha256 = "4d8d6244320dd751590f9100cf39fd7a4b75cd901e1f3ffdfd6f048328883695",
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Needed by, at least, com_github_bazelbuild_buildtools.
+# TODO(https://github.com/bazelbuild/bazel/issues/1943): Remove once recursive
+# workspaces are supported, unless we actually have to reference this directly.
+git_repository(
+    name = "io_bazel",
+    remote = "https://github.com/bazelbuild/bazel.git",
+    tag = "0.20.0",
 )
 
-# TODO(jmmv): Drop in favor of a new rules_go release once the commit below is
-# part of one.
 git_repository(
-    name = "com_github_bazelbuild_rules_go",
-    remote = "https://github.com/bazelbuild/rules_go.git",
-    commit = "dd3c631c31c8d4e3b5bcffc4b66e8c092172ed89",
+    name = "com_github_bazelbuild_buildtools",
+    remote = "https://github.com/bazelbuild/buildtools.git",
+    commit = "ab1d6a0ca532b7b7f3450a42d5cbcfdcd736fd41",
+)
+
+# Needed by, at least, org_golang_x_lint.
+# TODO(https://github.com/bazelbuild/bazel/issues/1943): Remove once recursive
+# workspaces are supported, unless we actually have to reference this directly.
+git_repository(
+    name = "bazel_skylib",
+    remote = "https://github.com/bazelbuild/bazel-skylib.git",
+    commit = "c00ef493869e2966d47508e8625aae723a4a3054",
+)
+
+http_archive(
+    name = "io_bazel_rules_go",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.4/rules_go-0.16.4.tar.gz"],
+    sha256 = "62ec3496a00445889a843062de9930c228b770218c735eca89c67949cd967c3f",
 )
 
 http_archive(
     name = "bazel_gazelle",
-    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.9/bazel-gazelle-0.9.tar.gz",
-    sha256 = "0103991d994db55b3b5d7b06336f8ae355739635e0c2379dea16b8213ea5a223",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz"],
+    sha256 = "6e875ab4b6bf64a38c352887760f21203ab054676d9c1b274963907e0768740d",
 )
 
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_register_toolchains",
-    "go_repository",
     "go_rules_dependencies",
 )
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 go_register_toolchains(go_version = "host")
 
 go_repository(
     name = "bazel_gopath",
     importpath = "github.com/DarkDNA/bazel-gopath",
-    commit = "f83ae8d403d0c826335a5edf4bbd1f7b0cf176e4",
+    commit = "46f9d0fc6e529be2f95558449fe7e181934124ee",
 
     # bazel-gopath ships with a proto file and also a precompiled version of it.
     # The proto file does not include the right Go options, which confuses
@@ -43,21 +61,21 @@ go_repository(
 )
 
 go_repository(
-    name = "golint",
-    importpath = "github.com/golang/lint",
-    commit = "6aaf7c34af0f4c36a57e0c429bace4d706d8e931",
+    name = "org_bazil_fuse",
+    importpath = "bazil.org/fuse",
+    commit = "65cc252bf6691cb3c7014bcb2c8dc29de91e3a7e",
 )
 
 go_repository(
-    name = "org_bazil_fuse",
-    importpath = "bazil.org/fuse",
-    commit = "371fbbdaa8987b715bdd21d6adc4c9b20155f748",
+    name = "org_golang_x_lint",
+    importpath = "golang.org/x/lint",
+    commit = "93c0bb5c83939f89e6238cefd42de38f33734409",
 )
 
 go_repository(
     name = "org_golang_x_sys",
     importpath = "golang.org/x/sys",
-    commit = "9b800f95dbbc54abff0acf7ee32d88ba4e328c89",
+    commit = "4d1cda033e0619309c606fc686de3adcf599539e",
 )
 
 gazelle_dependencies()

--- a/admin/install/BUILD.bazel
+++ b/admin/install/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//internal/shell:go_default_library",
-        "@com_github_bazelbuild_rules_go//go/tools/bazel:go_default_library",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )
 

--- a/admin/lint/BUILD.bazel
+++ b/admin/lint/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//internal/shell:go_default_library",
-        "@com_github_bazelbuild_rules_go//go/tools/bazel:go_default_library",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )
 
@@ -23,7 +23,7 @@ go_binary(
         "@bazel_gazelle//cmd/gazelle",
         "@com_github_bazelbuild_buildtools//buildifier",
         "@go_sdk//:bin/gofmt",
-        "@golint//golint",
+        "@org_golang_x_lint//golint",
     ],
     embed = [":go_default_library"],
     importpath = "github.com/bazelbuild/sandboxfs/admin/lint",

--- a/admin/lint/lint.go
+++ b/admin/lint/lint.go
@@ -157,7 +157,7 @@ func main() {
 
 	failed := false
 	for _, file := range files {
-		if !checkAll(file) {
+		if !checkAll(workspaceDir, file) {
 			failed = true
 		}
 	}

--- a/admin/travis-install.sh
+++ b/admin/travis-install.sh
@@ -22,12 +22,12 @@ install_bazel() {
     *) osname="${TRAVIS_OS_NAME}" ;;
   esac
 
-  local github="https://github.com/bazelbuild/bazel/releases/download/0.9.0"
-  local url="${github}/bazel-0.9.0-installer-${osname}-x86_64.sh"
-  wget -O install-bazel.sh "${url}"
-  chmod +x install-bazel.sh
-  ./install-bazel.sh --user
-  rm -f install-bazel.sh
+  local github="https://github.com/bazelbuild/bazel/releases/download/0.20.0"
+  local url="${github}/bazel-0.20.0-${osname}-x86_64"
+  mkdir -p ~/bin
+  wget -O ~/bin/bazel "${url}"
+  chmod +x ~/bin/bazel
+  PATH="${HOME}/bin:${PATH}"
 }
 
 install_fuse() {

--- a/integration/profiling_test.go
+++ b/integration/profiling_test.go
@@ -58,8 +58,8 @@ func TestProfiling_Http(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to read response from fake pprof endpoint: %v", err)
 	}
-	wantContents := "Unknown profile: fakename\n"
-	if string(contents) != wantContents {
+	wantContents := "Unknown profile.*"
+	if !utils.MatchesRegexp(wantContents, string(contents)) {
 		t.Errorf("Got unexpected pprof response %s; want %s", string(contents), wantContents)
 	}
 }

--- a/integration/read_write_test.go
+++ b/integration/read_write_test.go
@@ -298,6 +298,8 @@ func equivalentStats(stat1 os.FileInfo, stat2 os.FileInfo) error {
 // Tests calling this function should only start a sandboxfs instance with the desired configuration
 // and then immediately call this function.
 func doRenameTest(t *testing.T, oldOuterPath, newOuterPath, oldInnerPath, newInnerPath string) {
+	t.Helper()
+
 	utils.MustMkdirAll(t, filepath.Dir(oldOuterPath), 0755)
 	utils.MustMkdirAll(t, filepath.Dir(newOuterPath), 0755)
 	utils.MustMkdirAll(t, filepath.Dir(oldInnerPath), 0755)

--- a/integration/utils/checks.go
+++ b/integration/utils/checks.go
@@ -31,6 +31,8 @@ import (
 // MustMkdirAll wraps os.MkdirAll and immediately fails the test case on failure.
 // This is purely syntactic sugar to keep test setup short and concise.
 func MustMkdirAll(t *testing.T, path string, perm os.FileMode) {
+	t.Helper()
+
 	if err := os.MkdirAll(path, perm); err != nil {
 		t.Fatalf("Failed to create directory %s: %v", path, err)
 	}
@@ -43,6 +45,8 @@ func MustMkdirAll(t *testing.T, path string, perm os.FileMode) {
 // into account because Linux does not have an lchmod(2) system call, nor Go offers a mechanism to
 // call it on the systems that support it.
 func MustSymlink(t *testing.T, target string, path string) {
+	t.Helper()
+
 	if err := os.Symlink(target, path); err != nil {
 		t.Fatalf("Failed to create symlink %s: %v", path, err)
 	}
@@ -51,6 +55,8 @@ func MustSymlink(t *testing.T, target string, path string) {
 // MustWriteFile wraps ioutil.WriteFile and immediately fails the test case on failure.
 // This is purely syntactic sugar to keep test setup short and concise.
 func MustWriteFile(t *testing.T, path string, perm os.FileMode, contents string) {
+	t.Helper()
+
 	if err := ioutil.WriteFile(path, []byte(contents), perm); err != nil {
 		t.Fatalf("Failed to create file %s: %v", path, err)
 	}
@@ -59,6 +65,8 @@ func MustWriteFile(t *testing.T, path string, perm os.FileMode, contents string)
 // RequireRoot checks if the test is running as root and skips the test with the given reason
 // otherwise.
 func RequireRoot(t *testing.T, skipReason string) *UnixUser {
+	t.Helper()
+
 	if os.Getuid() != 0 {
 		t.Skipf(skipReason)
 	}

--- a/integration/utils/exec.go
+++ b/integration/utils/exec.go
@@ -263,6 +263,8 @@ func hasRootMapping(args ...string) bool {
 // and with rootSetup and the user set to nil.  See the documentation for this other function for
 // further details.
 func MountSetup(t *testing.T, args ...string) *MountState {
+	t.Helper()
+
 	return mountSetupFull(t, os.Stdout, os.Stderr, nil, nil, args...)
 }
 
@@ -273,6 +275,8 @@ func MountSetup(t *testing.T, args ...string) *MountState {
 // outputs and with the user set to nil.  See the documentation for this other function for
 // further details.
 func MountSetupWithRootSetup(t *testing.T, rootSetup func(string) error, args ...string) *MountState {
+	t.Helper()
+
 	return mountSetupFull(t, os.Stdout, os.Stderr, nil, rootSetup, args...)
 }
 
@@ -283,6 +287,8 @@ func MountSetupWithRootSetup(t *testing.T, rootSetup func(string) error, args ..
 // provided values and with rootSetup and the user set to nil.  See the documentation for this other
 // function for further details.
 func MountSetupWithOutputs(t *testing.T, stdout io.Writer, stderr io.Writer, args ...string) *MountState {
+	t.Helper()
+
 	return mountSetupFull(t, stdout, stderr, nil, nil, args...)
 }
 
@@ -293,6 +299,8 @@ func MountSetupWithOutputs(t *testing.T, stdout io.Writer, stderr io.Writer, arg
 // outputs, with rootSetup set to nil, and with the user set to the given value.  See the
 // documentation for this other function for further details.
 func MountSetupWithUser(t *testing.T, user *UnixUser, args ...string) *MountState {
+	t.Helper()
+
 	return mountSetupFull(t, os.Stdout, os.Stderr, user, nil, args...)
 }
 
@@ -321,6 +329,8 @@ func MountSetupWithUser(t *testing.T, user *UnixUser, args ...string) *MountStat
 // Callers must defer execution of MountState.TearDown() immediately on return to ensure the
 // background process and the mount point are cleaned up on test completion.
 func mountSetupFull(t *testing.T, stdout io.Writer, stderr io.Writer, user *UnixUser, rootSetup func(string) error, args ...string) *MountState {
+	t.Helper()
+
 	success := false
 
 	// Reset the test's umask to zero.  This allows tests to not care about how the umask
@@ -434,6 +444,8 @@ func mountSetupFull(t *testing.T, stdout io.Writer, stderr io.Writer, user *Unix
 // use of "defer".  Note, though, that such tests will only receive the first error encountered by
 // this function, and that the function will run to completion even if there were failures.
 func (s *MountState) TearDown(t *testing.T) error {
+	t.Helper()
+
 	var firstErr error
 	setFirstErr := func(err error) {
 		if firstErr == nil {

--- a/internal/sandbox/BUILD.bazel
+++ b/internal/sandbox/BUILD.bazel
@@ -8,17 +8,11 @@ go_library(
         "dir.go",
         "file.go",
         "node.go",
+        "node_darwin.go",
+        "node_linux.go",
         "sandbox.go",
         "symlink.go",
-    ] + select({
-        "@io_bazel_rules_go//go/platform:darwin": [
-            "node_darwin.go",
-        ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "node_linux.go",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
     importpath = "github.com/bazelbuild/sandboxfs/internal/sandbox",
     visibility = ["//:__subpackages__"],
     deps = [


### PR DESCRIPTION
The various changes in this PR upgrade all components of the `WORKSPACE` to newer versions and also make our Travis CI builds use a modern Bazel. These changes are all required to allow sandboxfs to use recent Bazel versions, as the old Go rules we used stopped working.