### PR TITLE
Fix remaining integration tests against the Rust variant

### DIFF
--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -78,7 +78,6 @@ do_rust() {
   # Ideally, by the time this alternative implementation is ready, this list
   # will be empty and we can then refactor this file to just test one version.
   local blacklist=(
-    TestDebug_FuseOpsInLog
     TestProfiling_Http
     TestProfiling_FileProfiles
     TestProfiling_BadConfiguration

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -78,9 +78,6 @@ do_rust() {
   # Ideally, by the time this alternative implementation is ready, this list
   # will be empty and we can then refactor this file to just test one version.
   local blacklist=(
-    TestCli_Help
-    TestCli_ExclusiveFlagsPriority
-    TestCli_Syntax
     TestDebug_FuseOpsInLog
     TestProfiling_Http
     TestProfiling_FileProfiles

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -88,7 +88,6 @@ do_rust() {
     TestProfiling_Http
     TestProfiling_FileProfiles
     TestProfiling_BadConfiguration
-    TestReadWrite_InodeReassignedAfterRecreation
     TestReconfiguration_Streams
     TestReconfiguration_Steps
     TestReconfiguration_Unmap

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -89,7 +89,6 @@ do_rust() {
     TestProfiling_FileProfiles
     TestProfiling_BadConfiguration
     TestReadWrite_InodeReassignedAfterRecreation
-    TestReadWrite_NestedMappingsInheritDirectoryProperties
     TestReconfiguration_Streams
     TestReconfiguration_Steps
     TestReconfiguration_Unmap

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -84,7 +84,6 @@ do_rust() {
     TestCli_ExclusiveFlagsPriority
     TestCli_Syntax
     TestDebug_FuseOpsInLog
-    TestLayout_MountPointDoesNotExist
     TestProfiling_Http
     TestProfiling_FileProfiles
     TestProfiling_BadConfiguration

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -79,8 +79,6 @@ do_rust() {
   # will be empty and we can then refactor this file to just test one version.
   local blacklist=(
     TestCli_Help
-    TestCli_Version
-    TestCli_VersionNotForRelease
     TestCli_ExclusiveFlagsPriority
     TestCli_Syntax
     TestDebug_FuseOpsInLog

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -88,7 +88,6 @@ do_rust() {
     TestProfiling_Http
     TestProfiling_FileProfiles
     TestProfiling_BadConfiguration
-    TestReadOnly_Attributes
     TestReadWrite_InodeReassignedAfterRecreation
     TestReadWrite_NestedMappingsInheritDirectoryProperties
     TestReconfiguration_Streams

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -78,9 +78,6 @@ do_rust() {
   # Ideally, by the time this alternative implementation is ready, this list
   # will be empty and we can then refactor this file to just test one version.
   local blacklist=(
-    TestProfiling_Http
-    TestProfiling_FileProfiles
-    TestProfiling_BadConfiguration
     TestReconfiguration_Streams
     TestReconfiguration_Steps
     TestReconfiguration_Unmap

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -78,6 +78,9 @@ func TestCli_Version(t *testing.T) {
 }
 
 func TestCli_VersionNotForRelease(t *testing.T) {
+	if utils.GetConfig().RustVariant {
+		t.Skipf("Rust variant of sandboxfs also bundles a version number")
+	}
 	if !utils.GetConfig().ReleaseBinary {
 		t.Skipf("Binary intentionally built not for release")
 	}

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -26,7 +26,23 @@ var (
 )
 
 func TestCli_Help(t *testing.T) {
-	wantStdout := `Usage: sandboxfs [flags...] mount-point
+	var wantStdout string
+	if utils.GetConfig().RustVariant {
+		wantStdout = `Usage: sandboxfs [options] MOUNT_POINT
+
+Options:
+    --allow other|root|self
+                        specifies who should have access to the file system
+                        (default: self)
+    --help              prints usage information and exits
+    --mapping TYPE:PATH:UNDERLYING_PATH
+                        type and locations of a mapping
+    --ttl TIMEs         how long the kernel is allowed to keep file metadata
+                        (default: 60s)
+    --version           prints version information and exits
+`
+	} else {
+		wantStdout = `Usage: sandboxfs [flags...] mount-point
 
 Available flags:
   -allow value
@@ -52,6 +68,7 @@ Available flags:
   -volume_name string
     	name for the sandboxfs volume (default "sandbox")
 `
+	}
 
 	stdout, stderr, err := utils.RunAndWait(0, "--help")
 	if err != nil {
@@ -101,12 +118,41 @@ func TestCli_ExclusiveFlagsPriority(t *testing.T) {
 		args           []string
 		wantExitStatus int
 		wantStdout     string
-		wantStderr     string
+		wantGoStderr   string
+		wantRustStderr string
 	}{
-		{"BogusFlagsWinOverEverything", []string{"--version", "--help", "--foo"}, 2, "", "not defined.*foo"},
-		{"BogusHFlagWinsOverEverything", []string{"--version", "--help", "-h"}, 2, "", "not defined.*-h"},
-		{"HelpWinsOverValidArgs", []string{"--version", "--mem_profile=foo", "--help", "--volume_name=foo"}, 0, "Usage:", ""},
-		{"VersionWinsOverValidArgsButHelp", []string{"--mem_profile=foo", "--version", "--volume_name=foo"}, 0, versionPattern, ""},
+		{
+			"BogusFlagsWinOverEverything",
+			[]string{"--version", "--help", "--foo"},
+			2,
+			"",
+			"not defined.*foo",
+			"Unrecognized option.*'foo'",
+		},
+		{
+			"BogusHFlagWinsOverEverything",
+			[]string{"--version", "--help", "-h"},
+			2,
+			"",
+			"not defined.*-h",
+			"Unrecognized option.*'h'",
+		},
+		{
+			"HelpWinsOverValidArgs",
+			[]string{"--version", "--allow=self", "--help", "/mnt"},
+			0,
+			"Usage:",
+			"",
+			"",
+		},
+		{
+			"VersionWinsOverValidArgsButHelp",
+			[]string{"--allow=other", "--version", "/mnt"},
+			0,
+			versionPattern,
+			"",
+			"",
+		},
 	}
 	for _, d := range testData {
 		t.Run(d.name, func(t *testing.T) {
@@ -119,10 +165,16 @@ func TestCli_ExclusiveFlagsPriority(t *testing.T) {
 			} else if len(d.wantStdout) > 0 && !utils.MatchesRegexp(d.wantStdout, stdout) {
 				t.Errorf("Got %s; want stdout to match %s", stdout, d.wantStdout)
 			}
-			if len(d.wantStderr) == 0 && len(stderr) > 0 {
+			var wantStderr string
+			if utils.GetConfig().RustVariant {
+				wantStderr = d.wantRustStderr
+			} else {
+				wantStderr = d.wantGoStderr
+			}
+			if len(wantStderr) == 0 && len(stderr) > 0 {
 				t.Errorf("Got %s; want stderr to be empty", stderr)
-			} else if len(d.wantStderr) > 0 && !utils.MatchesRegexp(d.wantStderr, stderr) {
-				t.Errorf("Got %s; want stderr to match %s", stderr, d.wantStderr)
+			} else if len(wantStderr) > 0 && !utils.MatchesRegexp(wantStderr, stderr) {
+				t.Errorf("Got %s; want stderr to match %s", stderr, wantStderr)
 			}
 		})
 	}
@@ -132,23 +184,66 @@ func TestCli_Syntax(t *testing.T) {
 	testData := []struct {
 		name string
 
-		args       []string
-		wantStderr string
+		args           []string
+		wantGoStderr   string
+		wantRustStderr string
 	}{
-		{"InvalidFlag", []string{"--foo"}, "not defined.*-foo"},
-		{"InvalidHFlag", []string{"-h"}, "not defined.*-h"},
-		{"NoArguments", []string{}, "invalid number of arguments"},
-		{"TooManyArguments", []string{"mount-point", "extra"}, "invalid number of arguments"},
-
-		{"InvalidFlagWinsOverHelp", []string{"--invalid_flag", "--help"}, "not defined.*-invalid_flag"},
+		{
+			"InvalidFlag",
+			[]string{"--foo"},
+			"not defined.*-foo",
+			"Unrecognized option.*'foo'",
+		},
+		{
+			"InvalidHFlag",
+			[]string{"-h"},
+			"not defined.*-h",
+			"Unrecognized option.*'h'",
+		},
+		{
+			"NoArguments",
+			[]string{},
+			"invalid number of arguments",
+			"invalid number of arguments",
+		},
+		{
+			"TooManyArguments",
+			[]string{"mount-point", "extra"},
+			"invalid number of arguments",
+			"invalid number of arguments",
+		},
+		{
+			"InvalidFlagWinsOverHelp",
+			[]string{"--invalid_flag", "--help"},
+			"not defined.*-invalid_flag",
+			"Unrecognized option.*'invalid_flag'",
+		},
 		// TODO(jmmv): For consistency with all previous tests, an invalid number of
-		// arguments should win over --help, but it currently does not.  Fix or turn help
-		// into a command of its own for consistency.
-		// {"InvalidArgumentsWinOverHelp", []string{"--help", "foo"}, "number of arguments"},
-
-		{"MappingMissingTarget", []string{"--mapping=ro:/foo"}, `invalid value "ro:/foo" for flag -mapping: flag "ro:/foo": expected contents to be of the form TYPE:MAPPING:TARGET`},
-		{"MappingRelativeTarget", []string{"--mapping=rw:/:relative/path"}, `invalid value "rw:/:relative/path" for flag -mapping: path "relative/path": target must be an absolute path`},
-		{"MappingBadType", []string{"--mapping=row:/foo:/bar"}, `invalid value "row:/foo:/bar" for flag -mapping: flag "row:/foo:/bar": unknown type row; must be one of ro,rw`},
+		// arguments should win over --help, but it currently does not.
+		// {
+		// 	"InvalidArgumentsWinOverHelp",
+		// 	[]string{"--help", "foo"},
+		// 	"invalid number of arguments",
+		// 	"invalid number of arguments",
+		// },
+		{
+			"MappingMissingTarget",
+			[]string{"--mapping=ro:/foo"},
+			`invalid value "ro:/foo" for flag -mapping: flag "ro:/foo": expected contents to be of the form TYPE:MAPPING:TARGET`,
+			`bad mapping ro:/foo: expected three colon-separated fields`,
+		},
+		{
+			"MappingRelativeTarget",
+			[]string{"--mapping=rw:/:relative/path"},
+			`invalid value "rw:/:relative/path" for flag -mapping: path "relative/path": target must be an absolute path`,
+			`bad mapping rw:/:relative/path: path "relative/path" is not absolute`,
+		},
+		{
+			"MappingBadType",
+			[]string{"--mapping=row:/foo:/bar"},
+			`invalid value "row:/foo:/bar" for flag -mapping: flag "row:/foo:/bar": unknown type row; must be one of ro,rw`,
+			`bad mapping row:/foo:/bar: type was row but should be ro or rw`,
+		},
 	}
 	for _, d := range testData {
 		t.Run(d.name, func(t *testing.T) {
@@ -159,8 +254,14 @@ func TestCli_Syntax(t *testing.T) {
 			if len(stdout) > 0 {
 				t.Errorf("Got %s; want stdout to be empty", stdout)
 			}
-			if !utils.MatchesRegexp(d.wantStderr, stderr) {
-				t.Errorf("Got %s; want stderr to match %s", stderr, d.wantStderr)
+			var wantStderr string
+			if utils.GetConfig().RustVariant {
+				wantStderr = d.wantRustStderr
+			} else {
+				wantStderr = d.wantGoStderr
+			}
+			if !utils.MatchesRegexp(wantStderr, stderr) {
+				t.Errorf("Got %s; want stderr to match %s", stderr, wantStderr)
 			}
 			if !utils.MatchesRegexp("--help", stderr) {
 				t.Errorf("Got %s; want --help mention in stderr", stderr)

--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -22,6 +22,10 @@ import (
 )
 
 func TestDebug_FuseOpsInLog(t *testing.T) {
+	if utils.GetConfig().RustVariant {
+		t.Skipf("Test is nonsensical in the Rust variant: logging is enabled via environment variables and they affect all libraries equally")
+	}
+
 	stderr := new(bytes.Buffer)
 
 	state := utils.MountSetupWithOutputs(t, nil, stderr, "--debug", "--mapping=ro:/:%ROOT%")

--- a/integration/layout_test.go
+++ b/integration/layout_test.go
@@ -31,7 +31,12 @@ func TestLayout_MountPointDoesNotExist(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	mountPoint := filepath.Join(tempDir, "non-existent")
-	wantStderr := "unable to mount: " + mountPoint + " does not exist\n"
+	var wantStderr string
+	if utils.GetConfig().RustVariant {
+		wantStderr = "Failed to mount " + mountPoint + ".*No such"
+	} else {
+		wantStderr = "unable to mount: " + mountPoint + " does not exist"
+	}
 
 	stdout, stderr, err := utils.RunAndWait(1, "--mapping=ro:/:"+tempDir, mountPoint)
 	if err != nil {

--- a/integration/profiling_test.go
+++ b/integration/profiling_test.go
@@ -33,6 +33,10 @@ import (
 var listenAddressRegex = regexp.MustCompile(`starting HTTP server on ([^:]+:\d+)`)
 
 func TestProfiling_Http(t *testing.T) {
+	if utils.GetConfig().RustVariant {
+		t.Skipf("Test is nonsensical in the Rust variant: it does not support profiling in the same way as the Go one does")
+	}
+
 	stderr := new(bytes.Buffer)
 	state := utils.MountSetupWithOutputs(t, nil, stderr, "--listen_address=localhost:0", "--mapping=ro:/:%ROOT%")
 	defer state.TearDown(t)
@@ -65,6 +69,10 @@ func TestProfiling_Http(t *testing.T) {
 }
 
 func TestProfiling_FileProfiles(t *testing.T) {
+	if utils.GetConfig().RustVariant {
+		t.Skipf("Test is nonsensical in the Rust variant: it does not support profiling in the same way as the Go one does")
+	}
+
 	tempDir, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatalf("Failed to create temporary directory: %v", err)
@@ -107,6 +115,10 @@ func TestProfiling_FileProfiles(t *testing.T) {
 }
 
 func TestProfiling_BadConfiguration(t *testing.T) {
+	if utils.GetConfig().RustVariant {
+		t.Skipf("Test is nonsensical in the Rust variant: it does not support profiling in the same way as the Go one does")
+	}
+
 	incompatibleSettings := "invalid profiling settings: file-based CPU or memory profiling are incompatible with a listening address\n"
 
 	testData := []struct {

--- a/integration/read_only_test.go
+++ b/integration/read_only_test.go
@@ -226,8 +226,16 @@ func TestReadOnly_Attributes(t *testing.T) {
 			t.Errorf("Got rdev %v for %s, want %v", innerStat.Rdev, innerPath, outerStat.Rdev)
 		}
 
-		if innerStat.Blksize != outerStat.Blksize {
-			t.Errorf("Got blocksize %v for %s, want %v", innerStat.Blksize, innerPath, outerStat.Blksize)
+		wantBlksize := outerStat.Blksize
+		if utils.GetConfig().RustVariant {
+			// The FUSE bindings for Rust only implement version 7.8 of the kernel
+			// protocol, which does not allow returning a block size from the getattr
+			// call.  Such a feature appeared with version 7.9.  The value we get is
+			// hardcoded so cope with it here.
+			wantBlksize = 65536
+		}
+		if innerStat.Blksize != wantBlksize {
+			t.Errorf("Got blocksize %v for %s, want %v", innerStat.Blksize, innerPath, wantBlksize)
 		}
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ extern crate getopts;
 extern crate sandboxfs;
 extern crate time;
 
-use failure::Error;
+use failure::{Error, ResultExt};
 use getopts::Options;
 use std::env;
 use std::path::{Path, PathBuf};
@@ -193,12 +193,13 @@ fn safe_main(program: &str, args: &[String]) -> Result<(), Error> {
     };
 
     let mount_point = if matches.free.len() == 1 {
-        &matches.free[0]
+        Path::new(&matches.free[0])
     } else {
         return Err(UsageError { message: "invalid number of arguments".to_string() }.into());
     };
 
-    sandboxfs::mount(Path::new(mount_point), &options, &mappings, ttl)?;
+    sandboxfs::mount(mount_point, &options, &mappings, ttl)
+        .context(format!("Failed to mount {}", mount_point.display()))?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,11 @@ fn usage(program: &str, opts: &Options) {
     print!("{}", opts.usage(&brief));
 }
 
+/// Prints version information to stdout.
+fn version() {
+    println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+}
+
 /// Program's entry point.  This is a "safe" version of `main` in the sense that this doesn't
 /// directly handle errors: all errors are returned to the caller for consistent reporter to the
 /// user depending on their type.
@@ -168,10 +173,16 @@ fn safe_main(program: &str, args: &[String]) -> Result<(), Error> {
     opts.optopt("", "ttl",
         &format!("how long the kernel is allowed to keep file metadata (default: {})", DEFAULT_TTL),
         &format!("TIME{}", SECONDS_SUFFIX));
+    opts.optflag("", "version", "prints version information and exits");
     let matches = opts.parse(args)?;
 
     if matches.opt_present("help") {
         usage(&program, &opts);
+        return Ok(());
+    }
+
+    if matches.opt_present("version") {
+        version();
         return Ok(());
     }
 

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -417,7 +417,10 @@ pub trait Node {
     }
 
     /// Deletes the empty directory `_name`.
-    fn rmdir(&self, _name: &OsStr) -> NodeResult<()> {
+    ///
+    /// `_cache` is the file system-wide bookkeeping object that caches underlying paths to nodes,
+    /// which needs to be update to account for the node removal.
+    fn rmdir(&self, _name: &OsStr, _cache: &Cache) -> NodeResult<()> {
         panic!("Not implemented");
     }
 
@@ -437,7 +440,10 @@ pub trait Node {
     }
 
     /// Deletes the file `_name`.
-    fn unlink(&self, _name: &OsStr) -> NodeResult<()> {
+    ///
+    /// `_cache` is the file system-wide bookkeeping object that caches underlying paths to nodes,
+    /// which needs to be update to account for the node removal.
+    fn unlink(&self, _name: &OsStr, _cache: &Cache) -> NodeResult<()> {
         panic!("Not implemented");
     }
 }


### PR DESCRIPTION
This set of commits fixes all remaining integration tests (other than the reconfiguration ones, which are in #52) so that they can pass with the Rust variant.

These changes are a mixture of actual code fixes, trivial fixes in the tests, and a mixture of both in some cases. I've also taken the liberty to just completely disabling some tests that won't make sense in the Rust variant and that I'll probably just delete along with the Go code.