### PR TITLE
Fix various issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,9 @@ signal-hook = "0.1"
 time = "0.1"
 
 [dependencies.fuse]
-# TODO(jmmv): Replace this with 0.4 or an upstream commit once
-# https://github.com/zargony/rust-fuse/pull/119 is merged.
-git = "https://github.com/jmmv/rust-fuse.git"
-rev = "07c47e9cc311a0d2890785d7a4098b76cb33a2ad"
+# TODO(jmmv): Replace this with 0.4 once released.
+git = "https://github.com/zargony/rust-fuse.git"
+rev = "bbe450403abd47e719c922f3025edee727ea004b"
 
 [dependencies.nix]
 # TODO(jmmv): Replace this with 0.12 once released.

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -120,22 +120,25 @@ do_rust() {
       echo "Skipping blacklisted test ${t}" 1>&2
       continue
     fi
-    valid+="${t}"
+    valid+=("${t}")
   done
   set -x
 
   [ "${#valid[@]}" -gt 0 ] || return 0  # Only run tests if any are valid.
+  local failed=no
   for t in "${valid[@]}"; do
     go test -v -timeout=600s -test.run="^${t}$" \
         github.com/bazelbuild/sandboxfs/integration \
-        -sandboxfs_binary="${bin}" -release_build=false
+        -sandboxfs_binary="${bin}" -release_build=false \
+        -rust_variant=true || failed=yes
 
     sudo -H "${rootenv[@]}" -s \
         go test -v -timeout=600s -test.run="^${t}$" \
         github.com/bazelbuild/sandboxfs/integration \
-        -sandboxfs_binary="$(pwd)/sandboxfs" -release_build=false \
-        -rust_variant=true
+        -sandboxfs_binary="${bin}" -release_build=false \
+        -rust_variant=true || failed=yes
   done
+  [ "${failed}" = no ]
 }
 
 case "${DO}" in

--- a/integration/read_only_test.go
+++ b/integration/read_only_test.go
@@ -432,11 +432,7 @@ func TestReadOnly_ReaddirFromFileFails(t *testing.T) {
 	case "darwin":
 		wantErr = unix.EINVAL
 	case "linux":
-		if utils.GetConfig().RustVariant {
-			wantErr = unix.EINVAL
-		} else {
-			wantErr = unix.ENOTDIR
-		}
+		wantErr = unix.ENOTDIR
 	default:
 		t.Fatalf("Don't know how this test behaves in this platform")
 	}

--- a/integration/read_only_test.go
+++ b/integration/read_only_test.go
@@ -232,7 +232,14 @@ func TestReadOnly_Attributes(t *testing.T) {
 			// protocol, which does not allow returning a block size from the getattr
 			// call.  Such a feature appeared with version 7.9.  The value we get is
 			// hardcoded so cope with it here.
-			wantBlksize = 65536
+			switch runtime.GOOS {
+			case "darwin":
+				wantBlksize = 65536
+			case "linux":
+				wantBlksize = 4096
+			default:
+				t.Fatalf("Don't know how this test behaves in this platform")
+			}
 		}
 		if innerStat.Blksize != wantBlksize {
 			t.Errorf("Got blocksize %v for %s, want %v", innerStat.Blksize, innerPath, wantBlksize)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -624,7 +624,13 @@ impl fuse::Filesystem for SandboxFS {
 /// Mounts a new sandboxfs instance on the given `mount_point` and maps all `mappings` within it.
 pub fn mount(mount_point: &Path, options: &[&str], mappings: &[Mapping], ttl: Timespec)
     -> Fallible<()> {
-    let os_options = options.iter().map(|o| o.as_ref()).collect::<Vec<&OsStr>>();
+    let mut os_options = options.iter().map(|o| o.as_ref()).collect::<Vec<&OsStr>>();
+
+    // Delegate permissions checks to the kernel for efficiency and to avoid having to implement
+    // them on our own.
+    os_options.push(OsStr::new("-o"));
+    os_options.push(OsStr::new("default_permissions"));
+
     let fs = SandboxFS::create(mappings, ttl)?;
     info!("Mounting file system onto {:?}", mount_point);
 

--- a/src/nodes/conv.rs
+++ b/src/nodes/conv.rs
@@ -46,7 +46,7 @@ fn system_time_to_timespec(path: &Path, name: &str, time: &io::Result<SystemTime
             }
         },
         Err(e) => {
-            warn!("File system did not return a {} timestamp for {:?}: {}", name, path, e);
+            debug!("File system did not return a {} timestamp for {:?}: {}", name, path, e);
             BAD_TIME
         },
     }

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -416,7 +416,8 @@ impl Node for Dir {
         if let Some(dirent) = state.children.get(name) {
             // TODO(jmmv): We should probably mark this dirent as an explicit mapping if it already
             // wasn't, but the Go variant of this code doesn't do this -- so investigate later.
-            ensure!(dirent.node.file_type_cached() == fuse::FileType::Directory, "Already mapped");
+            ensure!(dirent.node.file_type_cached() == fuse::FileType::Directory
+                && !remainder.is_empty(), "Already mapped");
             return dirent.node.map(remainder, underlying_path, writable, ids, cache);
         }
 

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -503,9 +503,10 @@ impl Node for Dir {
         };
 
         let exp_filetype = match sflag {
-            sys::stat::SFlag::S_IFCHR => fuse::FileType::CharDevice,
             sys::stat::SFlag::S_IFBLK => fuse::FileType::BlockDevice,
+            sys::stat::SFlag::S_IFCHR => fuse::FileType::CharDevice,
             sys::stat::SFlag::S_IFIFO => fuse::FileType::NamedPipe,
+            sys::stat::SFlag::S_IFREG => fuse::FileType::RegularFile,
             _ => {
                 warn!("mknod received request to create {} with type {:?}, which is not supported",
                     path.display(), sflag);

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -130,7 +130,7 @@ fn setattr_owners(attr: &mut fuse::FileAttr, path: Option<&PathBuf>, uid: Option
         unistd::fchownat(None, p, uid, gid, unistd::FchownatFlags::NoFollowSymlink));
     if result.is_ok() {
         attr.uid = uid.map_or(attr.uid, u32::from);
-        attr.gid = uid.map_or(attr.gid, u32::from);
+        attr.gid = gid.map_or(attr.gid, u32::from);
     }
     result
 }

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -111,8 +111,14 @@ fn setattr_mode(attr: &mut fuse::FileAttr, path: Option<&PathBuf>, mode: Option<
     }
     let perm = mode.bits() as u16;
 
+    if attr.kind == fuse::FileType::Symlink {
+        // TODO(jmmv): Should use NoFollowSymlink to support changing the mode of a symlink if
+        // requested to do so, but this is not supported on Linux.
+        return Err(nix::Error::from_errno(Errno::EOPNOTSUPP));
+    }
+
     let result = try_path(path, |p|
-        sys::stat::fchmodat(None, p, mode, sys::stat::FchmodatFlags::NoFollowSymlink));
+        sys::stat::fchmodat(None, p, mode, sys::stat::FchmodatFlags::FollowSymlink));
     if result.is_ok() {
         attr.perm = perm;
     }


### PR DESCRIPTION
Ok, this is embarrassing. The execution of the integration tests against the Rust variant was... just broken. I discovered this while removing all the complexity of the blacklist as part of the reconfigurations PR, which cannot be merged yet.

These changes properly enable the tests to run and fix a bunch of issues. Luckily there was not a lot of broken stuff left behind, partially because I had been running the tests locally before submitting new code.