### PR TITLE
Release 0.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ go_import_path: github.com/bazelbuild/sandboxfs
 env:
   - DO=install
   - DO=lint
+  - DO=macos_pkg
   - DO=package
   - DO=test
   - DO=test FEATURES=profiling
@@ -78,3 +79,7 @@ matrix:
     # platform.  We don't really inspect the profile results here.
     - env: DO=test FEATURES=profiling
       os: osx
+
+    # For the macOS packaging tests, don't do Linux; it makes no sense.
+    - env: DO=macos_pkg
+      os: linux

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,10 +1,42 @@
 # Installation instructions
 
-Given that there have not yet been any formal releases of sandboxfs, there
-currently are no prebuilt binaries available.  To use sandboxfs, you will
-have to build and install it from a fresh checkout of the GitHub tree.
+## Using the macOS installer
 
-1.  [Download and install Rust](https://www.rust-lang.org/).
+1.  [Download and install OSXFUSE](https://osxfuse.github.io/).
+
+1.  Download the `sandboxfs-<release>-<date>.pkg` file attached to the
+    latest release in the
+    [releases page](https://github.com/bazelbuild/sandboxfs/releases).
+
+1.  Double-click the downloaded file and follow the instructions.
+
+Should you want to uninstall sandboxfs at any point, you can run
+`/usr/local/share/sandboxfs/uninstall.sh` to cleanly remove all installed
+files.
+
+## From crates.io
+
+1.  [Download and install Rust](https://www.rust-lang.org/).  If you already
+    had it installed, make sure you are on a new-enough version by running
+    `rustup update`.
+
+1.  Download and install FUSE for your system.  On Linux this will vary
+    on a distribution basis, and on macOS you can [install
+    OSXFUSE](https://osxfuse.github.io/).
+
+1.  Run `cargo install sandboxfs`.
+
+## From a GitHub checkout
+
+1.  [Download and install Rust](https://www.rust-lang.org/).  If you already
+    had it installed, make sure you are on a new-enough version by running
+    `rustup update`.
+
+1.  Download and install FUSE for your system.  On Linux this will vary
+    on a distribution basis, and on macOS you can [install
+    OSXFUSE](https://osxfuse.github.io/).
+
+1.  Download and install `pkg-config` or `pkgconf`.
 
 1.  Run `./configure` to generate the scripts that will allow installation.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,3 +68,20 @@ files.
 sandboxfs has optional support for the gperftools profiling tools.  If you have
 that package installed, you can pass `--features=profiling` to the `configure`
 script and sandboxfs's `--cpu_profile` flag will become functional.
+
+## macOS only: Enable "allow other" support in OSXFUSE
+
+In order to run system binaries within a sandboxfs mount point (which is
+the primary goal of using sandboxfs), you must enable OSXFUSE's "allow
+other" support; otherwise, necessary core macOS security services [will deny
+executions](http://julio.meroh.net/2017/10/fighting-execs-sandboxfs-macos.html).
+
+To do this, run the following for a one-time change:
+
+    sudo sysctl -w vfs.generic.osxfuse.tunables.allow_other=1
+
+Note that you cannot do this via `/etc/sysctl.conf` because the OSXFUSE
+kernel extension has not yet been loaded when this file is parsed.
+
+The macOS installer configures your system to do this automatically at
+every boot by using a launch agent.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
 # Major changes between releases
 
-## Changes in version 0.1
+## Changes in version 0.1.0
 
-**NOT RELEASED YET; STILL UNDER DEVELOPMENT.**
+**Released on 2019-02-05.**
+
+This is the first formal release of the sandboxfs project.
 
 **WARNING:** The interaction points with sandboxfs are subject to change at this
 point.  In particular, the command-line interface and the data format used to
-reconfigure sandboxfs in dynamic mode *will* most certainly change.
-
-* No changes recorded.
+reconfigure sandboxfs while it's running *will* most certainly change.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ not an official Google product.
 
 ## Releases
 
-sandboxfs is still under active development and there have not yet been any
-formal releases.
+The latest version of sandboxfs is 0.1.0 and was released on 2019-02-05.
 
 See the [installation instructions](INSTALL.md) for details on how to build
 and install sandboxfs.

--- a/admin/lint/checks.go
+++ b/admin/lint/checks.go
@@ -174,7 +174,7 @@ func checkAll(workspaceDir string, file string) bool {
 		}
 	}
 
-	if !isDocumentation && filepath.Base(file) != "settings.json.in" {
+	if !isDocumentation && filepath.Base(file) != "settings.json.in" && filepath.Ext(file) != ".plist" {
 		runCheck(checkLicense, file)
 	}
 

--- a/admin/make-macos-pkg.sh
+++ b/admin/make-macos-pkg.sh
@@ -1,0 +1,125 @@
+#! /bin/sh
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Builds a self-installer package for macOS.
+#
+# This assumes Cargo, OSXFUSE, and pkg-config are installed.
+#
+# All arguments given to this script are delegated to "configure".
+
+
+# Directory name of the running script.
+DirName="$(dirname "${0}")"
+
+
+# Base name of the running script.
+ProgName="${0##*/}"
+
+
+# Prints the given error message to stderr and exits.
+#
+# \param ... The message to print.
+err() {
+    echo "${ProgName}: E: $*" 1>&2
+    exit 1
+}
+
+
+# Prints the given informational message to stderr.
+#
+# \param ... The message to print.
+info() {
+    echo "${ProgName}: I: $*" 1>&2
+}
+
+
+# Modifies the fresh sandboxfs installation for our packaging needs.
+#
+# \param root Path to the new file system root used to build the package.
+configure_root() {
+    local root="${1}"; shift
+
+    mkdir -p "${root}/etc/paths.d"
+    cat >"${root}/etc/paths.d/sandboxfs" <<EOF
+/usr/local/bin
+EOF
+
+    mkdir -p "${root}/usr/local/libexec/sandboxfs"
+    cat >"${root}/usr/local/libexec/sandboxfs/uninstall.sh" <<EOF
+#! /bin/sh
+
+cd /
+for f in \$(tail -r /usr/local/share/sandboxfs/manifest); do
+    if [ ! -d "\${f}" ]; then
+        rm "\${f}"
+    else
+        # Some directories are shared with other packages (like
+        # /usr/local/bin) so just ignore errors during their removal.
+        rmdir "\${f}" 2>/dev/null || true
+    fi
+done
+EOF
+    chmod +x "${root}/usr/local/libexec/sandboxfs/uninstall.sh"
+
+    mkdir -p "${root}/usr/local/share/sandboxfs"
+    ( cd "${root}" && find . >"${root}/usr/local/share/sandboxfs/manifest" )
+}
+
+
+# Program's entry point.
+main() {
+    [ "$(uname -s)" = Darwin ] || err "This script is for macOS only"
+    [ -x "${DirName}/../configure" ] || err "configure not found; make" \
+        "sure to run this from a cloned repository"
+
+    local tempdir
+    tempdir="$(mktemp -d "${TMPDIR:-/tmp}/${ProgName}.XXXXXX" 2>/dev/null)" \
+        || err "Failed to create temporary directory"
+    trap "rm -rf '${tempdir}'" EXIT
+
+    export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig  # For OSXFUSE.
+
+    info "Cloning fresh copy of the source tree"
+    git clone "${DirName}/.." "${tempdir}/src"
+
+    info "Building and installing into temporary root"
+    (
+        set -e
+        cd "${tempdir}/src"
+        ./configure --goroot=none --prefix=/usr/local "${@}"
+        make release
+        make install DESTDIR="${tempdir}/root"
+    ) || err "Build failed"
+
+    info "Preparing temporary root for packaging"
+    configure_root "${tempdir}/root"
+
+    local version="$(grep ^version "${tempdir}/src/Cargo.toml" \
+        | cut -d '"' -f 2)"
+    local revision="$(date +%Y%m%d)"
+    local pkgversion="${version}-${revision}"
+    local pkgfile="sandboxfs-${pkgversion}-macos.pkg"
+
+    info "Building package ${pkgfile}"
+    ( cd "${tempdir}/root" && find . ) | sed 's,^,MANIFEST: ,'
+    pkgbuild \
+        --identifier com.github.bazelbuild.sandboxfs \
+        --root "${tempdir}/root" \
+        --version "${pkgversion}" \
+        "${pkgfile}"
+}
+
+
+main "${@}"

--- a/admin/org.bazelbuild.sandboxfs.setup-osxfuse.plist
+++ b/admin/org.bazelbuild.sandboxfs.setup-osxfuse.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>org.bazelbuild.sandboxfs.setup-osxfuse</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/libexec/sandboxfs/setup-osxfuse.sh</string>
+    </array>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>LaunchOnlyOnce</key>
+    <true/>
+  </dict>
+</plist>

--- a/admin/setup-osxfuse.sh
+++ b/admin/setup-osxfuse.sh
@@ -1,0 +1,27 @@
+#! /bin/sh
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Startup script to load OSXFUSE and enable "-o allow_other".
+#
+# sandboxfs requires this setting in order for binaries mapped within the
+# sandbox to work.  See the following for more details:
+# http://julio.meroh.net/2017/10/fighting-execs-sandboxfs-macos.html
+#
+# We use a startup script instead of an entry in /etc/sysctl.conf because
+# it's easier to manage installation and deinstallation, and because we
+# must first ensure OSXFUSE is loaded in order to change its configuration.
+
+/Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse
+/usr/sbin/sysctl -w vfs.generic.osxfuse.tunables.allow_other=1

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -63,13 +63,15 @@ do_macos_pkg() {
   ./admin/make-macos-pkg.sh --cargo="${HOME}/.cargo/bin/cargo"
   local pkg="$(echo sandboxfs-*.*.*-????????-macos.pkg)"
 
-  find /etc /usr/local >before.list
-  sudo installer -pkg "${pkg}" -target /
+  sudo find /Library /etc /usr/local >before.list
+  sudo sysctl -w vfs.generic.osxfuse.tunables.allow_other=0
 
+  sudo installer -pkg "${pkg}" -target /
+  test "$(sysctl -n vfs.generic.osxfuse.tunables.allow_other)" -eq 1
   /usr/local/bin/sandboxfs --version
 
   sudo /usr/local/libexec/sandboxfs/uninstall.sh
-  find /etc /usr/local >after.list
+  sudo find /Library /etc /usr/local >after.list
   if ! cmp -s before.list after.list; then
     echo "Files left behind after installation:"
     diff -u before.list after.list

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -58,6 +58,25 @@ do_lint() {
   make lint
 }
 
+# Builds the macOS installer and verifies that it works.
+do_macos_pkg() {
+  ./admin/make-macos-pkg.sh --cargo="${HOME}/.cargo/bin/cargo"
+  local pkg="$(echo sandboxfs-*.*.*-????????-macos.pkg)"
+
+  find /etc /usr/local >before.list
+  sudo installer -pkg "${pkg}" -target /
+
+  /usr/local/bin/sandboxfs --version
+
+  sudo /usr/local/libexec/sandboxfs/uninstall.sh
+  find /etc /usr/local >after.list
+  if ! cmp -s before.list after.list; then
+    echo "Files left behind after installation:"
+    diff -u before.list after.list
+    false
+  fi
+}
+
 # Ensures that we can build a publishable crate and that it is sane.
 do_package() {
   # Intentionally avoids ./configure to certify that the code is buildable
@@ -75,7 +94,7 @@ do_test() {
 }
 
 case "${DO}" in
-  bazel|install|lint|package|test)
+  bazel|install|lint|macos_pkg|package|test)
     "do_${DO}"
     ;;
 

--- a/admin/travis-install.sh
+++ b/admin/travis-install.sh
@@ -96,7 +96,7 @@ case "${DO}" in
     install_rust
     ;;
 
-  install|package|test)
+  install|macos_pkg|package|test)
     install_fuse
     install_rust
     if [ "${FEATURES}" = profiling ]; then


### PR DESCRIPTION
These changes add a macOS installer, update the installation instructions and release notes, and publish 0.1.0.

I'm sending this out for review but this shouldn't be merged yet. I still need to gather some details about large Bazel builds with sandboxfs -- but other than that, I think we are ready for the first formal release.

Once that is done, the process will be:

1. Upload to crates.io and verify that "cargo install" works for this crate.
1. Create macOS installer.
1. Merge PR.
1. Upload installer to the releases page.