### PR TITLE
Test sandboxfs with a real Bazel build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,21 @@ env:
   - DO=lint
   - DO=test
 
+jobs:
+  include:
+    # Validating sandboxfs against a Bazel build is expensive (think over
+    # 25 minutes per job) and doesn't provide full proof that sandboxfs
+    # works.  We had cases where this test passed but sandboxfs had obvious
+    # bugs in it which were only triggered by running Bazel against more
+    # complex projects.  Therefore, it's OK to compromise and run this as a
+    # periodic job only.
+    - if: type = cron
+      env: DO=bazel
+      os: linux
+    - if: type = cron
+      env: DO=bazel
+      os: osx
+
 install: ./admin/travis-install.sh
 script: ./admin/travis-build.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
   - DO=lint
   - DO=test
 
-before_install: ./admin/travis-install.sh
+install: ./admin/travis-install.sh
 script: ./admin/travis-build.sh
 
 matrix:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,6 +14,11 @@ have to build and install it from a fresh checkout of the GitHub tree.
     1.  The build scripts will use `cargo` from your path but you can set
         a different location by passing the `--cargo=/path/to/cargo` flag.
 
+    1.  The build scripts will use `go` from your path but you can set a
+        different location by passing the `--goroot=/path/to/goroot` flag.
+        You can also use the magic `none` value to disable Go usage, but
+        this will prevent running the integration tests or the code linter.
+
 1.  Run `make release` to download all required dependencies and build the
     final binary.
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -45,18 +45,28 @@ check-unit: Cargo.toml $(RUST_SRCS)
 @IS_BMAKE@GO_SRCS != find integration -name "*.go"
 @IS_GNUMAKE@GO_SRCS = $(shell find integration -name "*.go")
 check-integration: target/debug/sandboxfs $(GO_SRCS)
-	GOPATH=$(GOPATH) GOROOT=$(GOROOT) $(GOROOT)/bin/go test \
-	    -v -timeout=600s \
-	    github.com/bazelbuild/sandboxfs/integration \
-	    -sandboxfs_binary="$$(pwd)/target/debug/sandboxfs" \
-	    $(CHECK_INTEGRATION_FLAGS)
+	@if [ -n "$(GOROOT)" ]; then \
+	    set -x; \
+	    GOPATH=$(GOPATH) GOROOT=$(GOROOT) $(GOROOT)/bin/go test \
+	        -v -timeout=600s \
+	        github.com/bazelbuild/sandboxfs/integration \
+	        -sandboxfs_binary="$$(pwd)/target/debug/sandboxfs" \
+	        $(CHECK_INTEGRATION_FLAGS); \
+	else \
+	    echo "WARNING: Go not enabled; integration tests not run"; \
+	fi
 
 .PHONY: lint
 lint:
 	$(CARGO) clippy -- -D warnings
-	PATH=$(GOPATH)/bin:$${PATH} GOPATH=$(GOPATH) GOROOT=$(GOROOT) \
-            $(GOROOT)/bin/go run \
-	    github.com/bazelbuild/sandboxfs/admin/lint $(LINT_FILES)
+	@if [ -n "$(GOROOT)" ]; then \
+	    set -x; \
+	    PATH=$(GOPATH)/bin:$${PATH} GOPATH=$(GOPATH) GOROOT=$(GOROOT) \
+	        $(GOROOT)/bin/go run \
+	        github.com/bazelbuild/sandboxfs/admin/lint $(LINT_FILES); \
+	else \
+	    echo "WARNING: Go not enabled; linter not run"; \
+	fi
 
 .PHONY: install
 install: target/release/sandboxfs

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -22,7 +22,8 @@ rootenv+=(PATH="${PATH}")
 readonly rootenv
 
 do_install() {
-  ./configure --cargo="${HOME}/.cargo/bin/cargo" --prefix="/opt/sandboxfs"
+  ./configure --cargo="${HOME}/.cargo/bin/cargo" --goroot=none \
+      --prefix="/opt/sandboxfs"
   make release
   make install DESTDIR="$(pwd)/destdir"
   test -x destdir/opt/sandboxfs/bin/sandboxfs

--- a/configure
+++ b/configure
@@ -106,7 +106,7 @@ setup_go() {
   local user_override="${1}"; shift
 
   if [ -n "${user_override}" ]; then
-    GOROOT="${user_override}"
+    [ "${user_override}" = none ] || GOROOT="${user_override}"
   else
     local go="$(find_progs go)"
     [ -n "${go}" ] && GOROOT="$(dirname "$(dirname "${go}")")"


### PR DESCRIPTION
Add a Travis CI configuration to use Bazel with sandboxfs to build a reasonably-sized project (Bazel itself), because Bazel is our primary and only user for now. This will ensure sandboxfs is usable for at least some builds and that its interface remains compatible with Bazel.

This increases presubmit times from about 10 minutes to over 25. I'm sure this will become annoying but let's see how far we can keep it.