### PR TITLE
Fix readdir of long directories

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,19 +538,10 @@ impl fuse::Filesystem for SandboxFS {
 
     fn readdir(&mut self, _req: &fuse::Request, _inode: u64, handle: u64, offset: i64,
                mut reply: fuse::ReplyDirectory) {
-        if offset == 0 {
-            let handle = self.find_handle(handle);
-            match handle.readdir(&self.ids, &self.cache, &mut reply) {
-                Ok(()) => reply.ok(),
-                Err(e) => reply.error(e.errno_as_i32()),
-            }
-        } else {
-            assert!(offset > 0, "Do not know what to do with a negative offset");
-            // Our handle.readdir() implementation reads the whole directory in one go.  Therefore,
-            // if we get an offset different than zero, it's because the kernel has already
-            // completed the first read and is asking us for extra entries -- of which there will
-            // be none.
-            reply.ok();
+        let handle = self.find_handle(handle);
+        match handle.readdir(&self.ids, &self.cache, offset, &mut reply) {
+            Ok(()) => reply.ok(),
+            Err(e) => reply.error(e.errno_as_i32()),
         }
     }
 

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -240,7 +240,11 @@ pub trait Handle {
         panic!("Not implemented")
     }
 
-    /// Reads all directory entries into the given reply object.
+    /// Reads directory entries into the given reply object until it is full.
+    ///
+    /// `_offset` indicates the "identifier" of the *last* entry we returned to the kernel in a past
+    /// `readdir` call, not the index of the first entry to return.  This difference is subtle but
+    /// important, as an offset of zero has to be handled especially.
     ///
     /// While this takes a `fuse::ReplyDirectory` object as a parameter for efficiency reasons, it
     /// is the responsibility of the caller to invoke `reply.ok()` and `reply.error()` on the same
@@ -249,8 +253,8 @@ pub trait Handle {
     ///
     /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
     /// nodes, used when readdir discovers an underlying node that was not yet known.
-    fn readdir(&self, _ids: &IdGenerator, _cache: &Cache, _reply: &mut fuse::ReplyDirectory)
-        -> NodeResult<()> {
+    fn readdir(&self, _ids: &IdGenerator, _cache: &Cache, _offset: i64,
+        _reply: &mut fuse::ReplyDirectory) -> NodeResult<()> {
         panic!("Not implemented");
     }
 


### PR DESCRIPTION
It turns out that ReplyDirectory::add() returns a boolean that indicates
whether the buffer for the reply to the kernel is full or not -- and we
were ignoring this completely.  As a result, readdirs of long directories
were truncated, leading to very strange build failures within Bazel (e.g.
because some jar files lacked entries late in the build).

Fix this by precomputing the full reply to the kernel on the first
readdir call, caching the output, and then returning it to the kernel in
smaller chunks.

-----

Surprised this hasn't surfaced until now given that some relatively-large builds within Bazel worked just fine. But things were obviously pretty broken.

This change paves the way to removing the `fuse::ReplyDirectory` parameter from the `Node` interface, which would be a nice thing to do. But... doing so means that the pagination ought to be tracked within `lib.rs` using yet another directory-level state object that would pretty closely mimic `OpenDir`. And this would also involve some locking issues... hence why I haven't tackled this yet.