### PR TITLE
Add CPU profiling support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ env:
   - DO=install
   - DO=lint
   - DO=test
+  - DO=test FEATURES=profiling
 
 jobs:
   include:
@@ -68,4 +69,9 @@ matrix:
     # For code linting, we just need to run this under a single configuration.
     # Trim all but one, and prefer Linux over macOS because it's much faster.
     - env: DO=lint
+      os: osx
+
+    # For the "profiling" feature, just make sure the code works under one
+    # platform.  We don't really inspect the profile results here.
+    - env: DO=test FEATURES=profiling
       os: osx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ version = "0.1.0"
 [badges]
 travis-ci = { repository = "bazelbuild/sandboxfs", branch = "master" }
 
+[features]
+default = []
+profiling = ["cpuprofiler"]
+
 [dependencies]
 env_logger = "0.5"
 failure = "~0.1.2"
@@ -23,6 +27,13 @@ serde_derive = "1.0"
 serde_json = "1.0"
 signal-hook = "0.1"
 time = "0.1"
+
+[dependencies.cpuprofiler]
+# TODO(https://github.com/AtheMathmo/cpuprofiler/pull/10): Replace this with
+# 0.0.4 or an upstream branch reference once released.
+git = "https://github.com/jmmv/cpuprofiler.git"
+rev = "a852024d6aed7202863dc43a3348e793aa432d54"
+optional = true
 
 [dependencies.fuse]
 # TODO(jmmv): Replace this with 0.4 once released.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,3 +30,9 @@ have to build and install it from a fresh checkout of the GitHub tree.
 
     *   You will (most likely) need superuser permissions to install
         under `/usr/local`, so run the previous command with `sudo`.
+
+## Profiling support
+
+sandboxfs has optional support for the gperftools profiling tools.  If you have
+that package installed, you can pass `--features=profiling` to the `configure`
+script and sandboxfs's `--cpu_profile` flag will become functional.

--- a/Makefile.in
+++ b/Makefile.in
@@ -15,6 +15,8 @@
 .PHONY: all
 all: Makefile debug
 
+CARGO_FLAGS = --features "$(FEATURES)"
+
 # TODO(jmmv): Should automatically reinvoke configure... but this is difficult
 # because we need to remember the flags originally passed by the user, and
 # we need to tell make to reload the Makefile somehow.
@@ -25,7 +27,7 @@ Makefile: configure Makefile.in
 @IS_BMAKE@RUST_SRCS != find src -name "*.rs"
 @IS_GNUMAKE@RUST_SRCS = $(shell find src -name "*.rs")
 target/debug/sandboxfs: Cargo.toml $(RUST_SRCS)
-	$(CARGO) build
+	$(CARGO) build $(CARGO_FLAGS)
 
 .PHONY: debug
 debug: target/debug/sandboxfs
@@ -34,13 +36,13 @@ debug: target/debug/sandboxfs
 release: target/release/sandboxfs
 
 target/release/sandboxfs: Cargo.toml $(RUST_SRCS)
-	$(CARGO) build --release
+	$(CARGO) build $(CARGO_FLAGS) --release
 
 .PHONY: check
 check: check-unit check-integration
 
 check-unit: Cargo.toml $(RUST_SRCS)
-	$(CARGO) test --verbose
+	$(CARGO) test $(CARGO_FLAGS) --verbose
 
 @IS_BMAKE@GO_SRCS != find integration -name "*.go"
 @IS_GNUMAKE@GO_SRCS = $(shell find integration -name "*.go")
@@ -50,6 +52,7 @@ check-integration: target/debug/sandboxfs $(GO_SRCS)
 	    GOPATH=$(GOPATH) GOROOT=$(GOROOT) $(GOROOT)/bin/go test \
 	        -v -timeout=600s \
 	        github.com/bazelbuild/sandboxfs/integration \
+	        -features="$(FEATURES)" \
 	        -sandboxfs_binary="$$(pwd)/target/debug/sandboxfs" \
 	        $(CHECK_INTEGRATION_FLAGS); \
 	else \
@@ -58,7 +61,7 @@ check-integration: target/debug/sandboxfs $(GO_SRCS)
 
 .PHONY: lint
 lint:
-	$(CARGO) clippy -- -D warnings
+	$(CARGO) clippy $(CARGO_FLAGS) -- -D warnings
 	@if [ -n "$(GOROOT)" ]; then \
 	    set -x; \
 	    PATH=$(GOPATH)/bin:$${PATH} GOPATH=$(GOPATH) GOROOT=$(GOROOT) \

--- a/admin/travis-install.sh
+++ b/admin/travis-install.sh
@@ -15,6 +15,9 @@
 
 set -e -u
 
+# Default to no features to avoid cluttering .travis.yml.
+: "${FEATURES:=}"
+
 install_bazel() {
   local osname
   case "${TRAVIS_OS_NAME}" in

--- a/admin/travis-install.sh
+++ b/admin/travis-install.sh
@@ -67,6 +67,21 @@ install_fuse() {
   esac
 }
 
+install_gperftools() {
+  case "${TRAVIS_OS_NAME}" in
+    linux)
+      # Assume install_fuse has already run, which updates the packages
+      # repository and also installs pkg-config.
+      sudo apt-get install -qq libgoogle-perftools-dev
+      ;;
+
+    *)
+      echo "Don't know how to install gperftools for OS ${TRAVIS_OS_NAME}" 1>&2
+      exit 1
+      ;;
+  esac
+}
+
 install_rust() {
   # We need to manually install Rust because we can only specify a single
   # language in .travis.yml, and that language is Go for now.
@@ -84,6 +99,9 @@ case "${DO}" in
   install|test)
     install_fuse
     install_rust
+    if [ "${FEATURES}" = profiling ]; then
+      install_gperftools
+    fi
     ;;
 
   lint)

--- a/configure
+++ b/configure
@@ -21,6 +21,7 @@ readonly SRCDIR="$(cd "$(dirname "${0}")" && pwd -P)"
 # Settings that end up in the Makefile.
 CARGO=cargo
 CLEANFILES=target
+FEATURES=
 GOPATH="$(pwd)/.gopath"
 GOROOT=
 IS_BMAKE=
@@ -29,7 +30,7 @@ PREFIX=
 DISTCLEANFILES="Makefile ${GOPATH}"
 
 # List of variables exposed to the Makefile.
-MK_VARS="CARGO CLEANFILES DISTCLEANFILES GOPATH GOROOT PREFIX"
+MK_VARS="CARGO CLEANFILES DISTCLEANFILES FEATURES GOPATH GOROOT PREFIX"
 
 # List of variables replaced in the Makefile.
 MK_SUBSTS="IS_BMAKE IS_GNUMAKE"
@@ -194,6 +195,7 @@ main() {
   for arg in "${@}"; do
     case "${arg}" in
       --cargo=*) cargo="${arg#*=}" ;;
+      --features=*) FEATURES="${arg#*=}" ;;
       --goroot=*) goroot="${arg#*=}" ;;
       --prefix=*) prefix="${arg#*=}" ;;
       *) err "Unknown argument ${arg}" ;;

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -32,6 +32,8 @@ Options:
     --allow other|root|self
                         specifies who should have access to the file system
                         (default: self)
+    --cpu_profile PATH  enables CPU profiling and writes a profile to the
+                        given path
     --help              prints usage information and exits
     --input [PATH]      where to read reconfiguration data from (- for stdin)
     --mapping TYPE:PATH:UNDERLYING_PATH

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 var (
+	features         = flag.String("features", "", "Whitespace-separated list of features enabled during the build")
 	releaseBuild     = flag.Bool("release_build", true, "Whether the tested binary was built for release or not")
 	sandboxfsBinary  = flag.String("sandboxfs_binary", "", "Path to the sandboxfs binary to test; cannot be empty and must point to an existent binary")
 	unprivilegedUser = flag.String("unprivileged_user", "", "Username of the system user to use for tests that require non-root permissions; can be empty, in which case those tests are skipped")
@@ -34,7 +35,7 @@ func TestMain(m *testing.M) {
 	if len(*sandboxfsBinary) == 0 {
 		log.Fatalf("--sandboxfs_binary must be provided")
 	}
-	if err := utils.SetConfigFromFlags(*releaseBuild, *sandboxfsBinary, *unprivilegedUser); err != nil {
+	if err := utils.SetConfigFromFlags(*features, *releaseBuild, *sandboxfsBinary, *unprivilegedUser); err != nil {
 		log.Fatalf("invalid flags configuration: %v", err)
 	}
 

--- a/integration/profiling_test.go
+++ b/integration/profiling_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package integration
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/sandboxfs/integration/utils"
+)
+
+func TestProfiling_OptionalSupport(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	profile := filepath.Join(tempDir, "cpu.prof")
+	arg := "--cpu_profile=" + profile
+
+	if _, ok := utils.GetConfig().Features["profiling"]; ok {
+		state := utils.MountSetup(t, arg, "--mapping=ro:/:%ROOT%")
+		// Explicitly stop sandboxfs (which is different to what most other tests do).
+		// We need to do this here to cause the profiles to be written to disk.
+		state.TearDown(t)
+
+		// Check if the profile exists and is not empty.  We cannot do much more complex
+		// verifications here, but ensuring the file is not empty is sufficient to verify
+		// that the profiles were actually written during termination.
+		stat, err := os.Lstat(profile)
+		if err != nil {
+			t.Fatalf("Cannot find expected profile %s", profile)
+		}
+		if stat.Size() == 0 {
+			t.Errorf("Expected profile %s is empty", profile)
+		}
+	} else {
+		_, stderr, err := utils.RunAndWait(1, arg, filepath.Join(tempDir, "root"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantStderr := "Failed to start CPU profile.*feature not enabled"
+		if !utils.MatchesRegexp(wantStderr, stderr) {
+			t.Errorf("Got %s; want stderr to match %s", stderr, wantStderr)
+		}
+	}
+}

--- a/integration/utils/config.go
+++ b/integration/utils/config.go
@@ -17,10 +17,15 @@ package utils
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 // Config represents the configuration for the integration tests as provided in the command line.
 type Config struct {
+	// Features contains the set of features enabled during the build.  This represents a set
+	// and therefore the values in the map are meaningless.
+	Features map[string]bool
+
 	// ReleaseBinary is true if the binary provided in SandboxfsBinary was built in release
 	// mode, false otherwise.
 	ReleaseBinary bool
@@ -41,9 +46,14 @@ var globalConfig *Config
 
 // SetConfigFromFlags initializes the test configuration based on the raw values provided by the
 // user on the command line.  Returns an error if any of those values is incorrect.
-func SetConfigFromFlags(releaseBinary bool, rawSandboxfsBinary string, unprivilegedUserName string) error {
+func SetConfigFromFlags(rawFeatures string, releaseBinary bool, rawSandboxfsBinary string, unprivilegedUserName string) error {
 	if globalConfig != nil {
 		panic("SetConfigFromFlags can only be called once")
+	}
+
+	features := make(map[string]bool)
+	for _, feature := range strings.Split(rawFeatures, " ") {
+		features[feature] = true
 	}
 
 	sandboxfsBinary, err := filepath.Abs(rawSandboxfsBinary)
@@ -60,6 +70,7 @@ func SetConfigFromFlags(releaseBinary bool, rawSandboxfsBinary string, unprivile
 	}
 
 	globalConfig = &Config{
+		Features:         features,
 		ReleaseBinary:    releaseBinary,
 		SandboxfsBinary:  sandboxfsBinary,
 		UnprivilegedUser: unprivilegedUser,

--- a/man/sandboxfs.1
+++ b/man/sandboxfs.1
@@ -20,10 +20,10 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl -allow Ar who
-.Op Fl -input Ar file
+.Op Fl -input Ar path
 .Op Fl -help
 .Op Fl -mapping Ar type:mapping:target
-.Op Fl -output Ar file
+.Op Fl -output Ar path
 .Op Fl -ttl Ar duration
 .Op Fl -version
 .Ar mount_point

--- a/man/sandboxfs.1
+++ b/man/sandboxfs.1
@@ -11,7 +11,7 @@
 .\" WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 .\" License for the specific language governing permissions and limitations
 .\" under the License.
-.Dd January 2, 2019
+.Dd January 15, 2019
 .Dt SANDBOXFS 1
 .Os
 .Sh NAME
@@ -20,6 +20,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl -allow Ar who
+.Op Fl -cpu_profile Ar path
 .Op Fl -input Ar path
 .Op Fl -help
 .Op Fl -mapping Ar type:mapping:target
@@ -88,6 +89,15 @@ This is because the
 .Xr amfid 8
 daemon, which implements the signature validation, runs as a different user
 and must be able to access the executables.
+.It Fl -cpu_profile Ar path
+Enables CPU profiling and stores the pprof log to the given
+.Ar path .
+This feature is only available if
+.Nm
+was built with gperftools support (i.e. with the compile-time
+.Sq profiler
+feature).
+Passing this flag when support is not enabled results in an error.
 .It Fl -input Ar path
 Points to the file from which to read new configuration requests, or
 .Sq -

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 // increases readability.
 #![allow(clippy::redundant_field_names)]
 
+#[cfg(feature = "profiling")] extern crate cpuprofiler;
 #[macro_use] extern crate failure;
 extern crate fuse;
 #[macro_use] extern crate log;
@@ -55,8 +56,11 @@ use time::Timespec;
 
 mod concurrent;
 mod nodes;
+mod profiling;
 mod reconfig;
 #[cfg(test)] mod testutils;
+
+pub use profiling::ScopedProfiler;
 
 /// An error indicating that a mapping specification (coming from the command line or from a
 /// reconfiguration operation) is invalid.

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,6 +205,8 @@ fn safe_main(program: &str, args: &[String]) -> Fallible<()> {
     let mut opts = Options::new();
     opts.optopt("", "allow", concat!("specifies who should have access to the file system",
         " (default: self)"), "other|root|self");
+    opts.optopt("", "cpu_profile", "enables CPU profiling and writes a profile to the given path",
+        "PATH");
     opts.optflag("", "help", "prints usage information and exits");
     opts.optflagopt("", "input", "where to read reconfiguration data from (- for stdin)", "PATH");
     opts.optmulti("", "mapping", "type and locations of a mapping", "TYPE:PATH:UNDERLYING_PATH");
@@ -265,6 +267,10 @@ fn safe_main(program: &str, args: &[String]) -> Fallible<()> {
         return Err(UsageError { message: "invalid number of arguments".to_string() }.into());
     };
 
+    let _profiler;
+    if let Some(path) = matches.opt_str("cpu_profile") {
+        _profiler = sandboxfs::ScopedProfiler::start(&path).context("Failed to start CPU profile")?;
+    };
     sandboxfs::mount(mount_point, &options, &mappings, ttl, input, output)
         .context(format!("Failed to mount {}", mount_point.display()))?;
     Ok(())

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -1,0 +1,70 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+#[cfg(feature = "profiling")] use cpuprofiler::PROFILER;
+use failure::Fallible;
+use std::path::Path;
+
+/// Facade for `cpuprofiler::PROFILER` to cope with the optional gperftools dependency and to
+/// ensure profiling stops on `drop`.
+pub struct ScopedProfiler {}
+
+impl ScopedProfiler {
+    #[cfg(not(feature = "profiling"))]
+    fn real_start<P: AsRef<Path>>(_path: P) -> Fallible<ScopedProfiler> {
+        Err(format_err!("Compile-time \"profiling\" feature not enabled"))
+    }
+
+    #[cfg(feature = "profiling")]
+    fn real_start<P: AsRef<Path>>(path: P) -> Fallible<ScopedProfiler> {
+        let path = path.as_ref();
+        let path_str = match path.to_str() {
+            Some(path_str) => path_str,
+            None => return Err(format_err!("Invalid path {}", path.display())),
+        };
+        let mut profiler = PROFILER.lock().unwrap();
+        info!("Starting CPU profiler and writing results to {}", path_str);
+        profiler.start(path_str.as_bytes()).unwrap();
+        Ok(ScopedProfiler {})
+    }
+
+    /// Starts the CPU profiler and stores the profile in the given `path`.
+    ///
+    /// This will fail if sandboxfs was built without the "profiler" feature.  This may fail if
+    /// there are problems initializing the profiler.
+    ///
+    /// Note that, due to the nature of profiling, there can only be one `ScopedPointer` active at
+    /// any given time.  Trying to create two instances of this will cause this method to block
+    /// until the other object is dropped.
+    pub fn start<P: AsRef<Path>>(path: P) -> Fallible<ScopedProfiler> {
+        ScopedProfiler::real_start(path)
+    }
+
+    #[cfg(not(feature = "profiling"))]
+    fn real_stop(&mut self) {
+    }
+
+    #[cfg(feature = "profiling")]
+    fn real_stop(&mut self) {
+        let mut profiler = PROFILER.lock().unwrap();
+        profiler.stop().expect("Profiler apparently not active, but it must have been");
+        info!("CPU profiler stopped");
+    }
+}
+
+impl Drop for ScopedProfiler {
+    fn drop(&mut self) {
+        self.real_stop()
+    }
+}


### PR DESCRIPTION
These changes add support for generating CPU profiles that can later be inspected with gperftools. The actual code needed to make this happen is tiny, but making the dependency on gperftools conditional has been the hard thing (and I really want this because gperftools has to be installed by hand upfront and is a C library, which would make sandboxfs compilation even harder).