### PR TITLE
Make sandboxfs publishable as a crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ go_import_path: github.com/bazelbuild/sandboxfs
 env:
   - DO=install
   - DO=lint
+  - DO=package
   - DO=test
   - DO=test FEATURES=profiling
 
@@ -69,6 +70,8 @@ matrix:
     # For code linting, we just need to run this under a single configuration.
     # Trim all but one, and prefer Linux over macOS because it's much faster.
     - env: DO=lint
+      os: osx
+    - env: DO=package
       os: osx
 
     # For the "profiling" feature, just make sure the code works under one

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ env_logger = "0.5"
 failure = "~0.1.2"
 getopts = "0.2"
 log = "0.4"
+nix = "0.12"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -39,11 +40,6 @@ optional = true
 # TODO(jmmv): Replace this with 0.4 once released.
 git = "https://github.com/zargony/rust-fuse.git"
 rev = "bbe450403abd47e719c922f3025edee727ea004b"
-
-[dependencies.nix]
-# TODO(jmmv): Replace this with 0.12 once released.
-git = "https://github.com/nix-rust/nix.git"
-rev = "8c3e43ccd4fc83583c16848a35410022f5a8efc9"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ profiling = ["cpuprofiler"]
 cpuprofiler = { version = "0.0", optional = true }
 env_logger = "0.5"
 failure = "~0.1.2"
+fuse = "0.3"
 getopts = "0.2"
 log = "0.4"
 nix = "0.12"
@@ -32,11 +33,6 @@ time = "0.1"
 
 [build-dependencies]
 pkg-config = "0.3"
-
-[dependencies.fuse]
-# TODO(jmmv): Replace this with 0.4 once released.
-git = "https://github.com/zargony/rust-fuse.git"
-rev = "bbe450403abd47e719c922f3025edee727ea004b"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 profiling = ["cpuprofiler"]
 
 [dependencies]
+cpuprofiler = { version = "0.0", optional = true }
 env_logger = "0.5"
 failure = "~0.1.2"
 getopts = "0.2"
@@ -29,12 +30,8 @@ serde_json = "1.0"
 signal-hook = "0.1"
 time = "0.1"
 
-[dependencies.cpuprofiler]
-# TODO(https://github.com/AtheMathmo/cpuprofiler/pull/10): Replace this with
-# 0.0.4 or an upstream branch reference once released.
-git = "https://github.com/jmmv/cpuprofiler.git"
-rev = "a852024d6aed7202863dc43a3348e793aa432d54"
-optional = true
+[build-dependencies]
+pkg-config = "0.3"
 
 [dependencies.fuse]
 # TODO(jmmv): Replace this with 0.4 once released.

--- a/Makefile.in
+++ b/Makefile.in
@@ -61,7 +61,8 @@ check-integration: target/debug/sandboxfs $(GO_SRCS)
 
 .PHONY: lint
 lint:
-	$(CARGO) clippy $(CARGO_FLAGS) -- -D warnings
+	$(CARGO) clippy $(CARGO_FLAGS) --all-features --all-targets \
+	    -- -D warnings
 	@if [ -n "$(GOROOT)" ]; then \
 	    set -x; \
 	    PATH=$(GOPATH)/bin:$${PATH} GOPATH=$(GOPATH) GOROOT=$(GOROOT) \

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -58,6 +58,13 @@ do_lint() {
   make lint
 }
 
+# Ensures that we can build a publishable crate and that it is sane.
+do_package() {
+  # Intentionally avoids ./configure to certify that the code is buildable
+  # directly from Cargo.
+  "${HOME}/.cargo/bin/cargo" publish --dry-run
+}
+
 # Runs sandboxfs' unit and integration tests.
 do_test() {
   ./configure --cargo="${HOME}/.cargo/bin/cargo" --features="${FEATURES}"
@@ -68,7 +75,7 @@ do_test() {
 }
 
 case "${DO}" in
-  bazel|install|lint|test)
+  bazel|install|lint|package|test)
     "do_${DO}"
     ;;
 

--- a/admin/travis-install.sh
+++ b/admin/travis-install.sh
@@ -96,7 +96,7 @@ case "${DO}" in
     install_rust
     ;;
 
-  install|test)
+  install|package|test)
     install_fuse
     install_rust
     if [ "${FEATURES}" = profiling ]; then

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,47 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+extern crate pkg_config;
+
+/// Configures the crate to link against `lib_name`.
+///
+/// The library is searched via the pkg-config file provided in `pc_name`, which provides us
+/// accurate information on how to find the library to link to.
+///
+/// However, for libraries that do not provide a pkg-config file, `fallback` can be set to true to
+/// just rely on the linker's search path to find it.  This is not accurate but is better than just
+/// failing to build.
+#[allow(unused)]
+fn find_library(pc_name: &str, lib_name: &str, fallback: bool) {
+    match pkg_config::Config::new().atleast_version("2.0").probe(pc_name) {
+        Ok(_) => (),
+        Err(_) => if fallback { println!("cargo:rustc-link-lib={}", lib_name) },
+    };
+}
+
+fn main () {
+    // Look for the libraries required by our cpuprofiler dependency.  Such dependency should do
+    // this on its own but it doesn't yet.  Given that we just need this during linking, we can
+    // cheat and do it ourselves.
+    //
+    // Note that older versions of gperftools (the package providing libprofiler) did not ship a
+    // pkg-config file, so we must fall back to using the linker's path.
+    //
+    // TODO(https://github.com/AtheMathmo/cpuprofiler/pull/10): Remove this in favor of upstream
+    // doing the right thing when this PR is accepted a new cpuprofiler version is released.
+    // TODO(https://github.com/dignifiedquire/rust-gperftools/pull/1): Remove this in favor of
+    // upstream doing the right thing when this PR is accepted and switch to rust-gperftools instead
+    // (which has the added benefit of providing heap profiling).
+    #[cfg(feature = "profiling")] find_library("libprofiler", "profiler", true);
+}

--- a/src/nodes/conv.rs
+++ b/src/nodes/conv.rs
@@ -190,6 +190,26 @@ pub fn flags_to_openoptions(flags: u32, allow_writes: bool) -> NodeResult<fs::Op
     Ok(options)
 }
 
+/// Asserts that two FUSE file attributes are equal.
+//
+// TODO(jmmv): Remove once rust-fuse 0.4 is released as it will derive Eq for FileAttr.
+pub fn fileattrs_eq(attr1: &fuse::FileAttr, attr2: &fuse::FileAttr) -> bool {
+    attr1.ino == attr2.ino
+        && attr1.kind == attr2.kind
+        && attr1.nlink == attr2.nlink
+        && attr1.size == attr2.size
+        && attr1.blocks == attr2.blocks
+        && attr1.atime == attr2.atime
+        && attr1.mtime == attr2.mtime
+        && attr1.ctime == attr2.ctime
+        && attr1.crtime == attr2.crtime
+        && attr1.perm == attr2.perm
+        && attr1.uid == attr2.uid
+        && attr1.gid == attr2.gid
+        && attr1.rdev == attr2.rdev
+        && attr1.flags == attr2.flags
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -293,7 +313,7 @@ mod tests {
         // modified and may not be queryable, so stub them out.
         attr.ctime = BAD_TIME;
         attr.crtime = BAD_TIME;
-        assert_eq!(&exp_attr, &attr);
+        assert!(fileattrs_eq(&exp_attr, &attr));
     }
 
     #[test]
@@ -330,7 +350,7 @@ mod tests {
         // modified and may not be queryable, so stub them out.
         attr.ctime = BAD_TIME;
         attr.crtime = BAD_TIME;
-        assert_eq!(&exp_attr, &attr);
+        assert!(fileattrs_eq(&exp_attr, &attr));
     }
 
     #[test]

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -227,7 +227,7 @@ pub fn setattr(path: Option<&PathBuf>, attr: &fuse::FileAttr, delta: &AttrDelta)
         // doing so on a node type basis.  Plus, who knows, if the kernel asked us to change the
         // size of anything other than a file, maybe we have to obey and try to do it.
         .and(setattr_size(&mut new_attr, path, delta.size));
-    if *attr != new_attr {
+    if !conv::fileattrs_eq(attr, &new_attr) {
         new_attr.ctime = updated_ctime;
     }
     result.and(Ok(new_attr))


### PR DESCRIPTION
These changes are to avoid depending on unpublished code, which has bitten me at the last minute before being able to publish sandboxfs as a crate... and that have had me confused for a couple of days trying to find a solution (which was trivial in the end actually).

Further, these changes add linting of the crate to ensure we don't hit this again in the future.