### PR TITLE
Use hashbrown for better performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "sandboxfs"
 readme = "README.md"
 repository = "https://github.com/bazelbuild/sandboxfs"
-version = "0.1.0"
+version = "0.1.1"
 
 [badges]
 travis-ci = { repository = "bazelbuild/sandboxfs", branch = "master" }
@@ -23,6 +23,7 @@ env_logger = "0.5"
 failure = "~0.1.2"
 fuse = "0.3"
 getopts = "0.2"
+hashbrown = "0.1"
 log = "0.4"
 nix = "0.12"
 serde = "1.0"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Major changes between releases
 
+## Changes in version 0.1.1
+
+**STILL UNDER DEVELOPMENT; NOT RELEASED YET.**
+
+* Switched to the hashbrown implementation of Swiss Tables for hash maps,
+  which brings an up to 1% performance improvement during Bazel builds
+  that use sandboxfs.
+
 ## Changes in version 0.1.0
 
 **Released on 2019-02-05.**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 #[cfg(feature = "profiling")] extern crate cpuprofiler;
 #[macro_use] extern crate failure;
 extern crate fuse;
+extern crate hashbrown;
 #[macro_use] extern crate log;
 extern crate nix;
 extern crate serde_derive;
@@ -39,9 +40,9 @@ extern crate signal_hook;
 extern crate time;
 
 use failure::{Fallible, Error, ResultExt};
+use hashbrown::HashMap;
 use nix::errno::Errno;
 use nix::{sys, unistd};
-use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fmt;
 use std::fs;

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -17,10 +17,10 @@ extern crate time;
 
 use {Cache, IdGenerator};
 use failure::{Fallible, ResultExt};
+use hashbrown::HashMap;
 use nix::{errno, fcntl, sys, unistd};
 use nix::dir as rawdir;
 use nodes::{ArcHandle, ArcNode, AttrDelta, Handle, KernelError, Node, NodeResult, conv, setattr};
-use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{self as unix_fs, DirBuilderExt, OpenOptionsExt};


### PR DESCRIPTION
Profiling sandboxfs during large builds showed a non-negligible (but
not large) amount of time going into hashtable operations.  Given
that we don't care about "secure" hashing, we can afford to switch
to a faster implementation like hashbrown, so do it here.

This yields a ~1% performance boost during the Bazel build of a large
application using sandboxfs.  The following numbers are based on 10
consecutive builds for each case and are in seconds:

std:       mean 3429.56, median 3425.00, stddev 21.56
hashbrown: mean 3394.50, median 3378.50, stddev 36.31