### PR TITLE
Allow creating files as different users

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,9 @@ failure = "~0.1.2"
 fuse = "0.3"
 getopts = "0.2"
 hashbrown = "0.1"
+lazy_static = "1.3.0"
 log = "0.4"
-nix = "0.12"
+nix = { git = "https://github.com/jmmv/nix.git", branch = "seteuid" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -37,3 +38,4 @@ pkg-config = "0.3"
 
 [dev-dependencies]
 tempfile = "3"
+users = "0.9"

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@
 * Fixed `--input` and `--output` to handle stdin and stdout correctly when
   running e.g. under `sudo`.
 
+* Make create operations honor the UID and GID of the caller user instead of
+  inheriting the permissions of whoever was running sandboxfs.  Only has an
+  effect when using `--allow=other` or `--allow=root`.
+
 ## Changes in version 0.1.0
 
 **Released on 2019-02-05.**

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -114,7 +114,7 @@ do_test() {
   # where those are and rerun them as root.  Note that we cannot simply
   # call cargo as sudo because it won't work with the user-specific
   # installation we performed.
-  local tests="$(find target/debug -maxdepth 1 -type f -name sandboxfs-*
+  local tests="$(find target/debug -maxdepth 1 -type f -name sandboxfs-* \
       -perm -0100)"
   if [ -z "${tests}" ]; then
     echo "Cannot find already-built unit tests"

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -109,6 +109,22 @@ do_test() {
   ./configure --cargo="${HOME}/.cargo/bin/cargo" --features="${FEATURES}"
   make debug
   make check
+
+  # Now that we have built all of our unit tests (via "make check"), find
+  # where those are and rerun them as root.  Note that we cannot simply
+  # call cargo as sudo because it won't work with the user-specific
+  # installation we performed.
+  local tests="$(find target/debug -maxdepth 1 -type f -name sandboxfs-*
+      -perm -0100)"
+  if [ -z "${tests}" ]; then
+    echo "Cannot find already-built unit tests"
+    find target
+    false
+  fi
+  for t in ${tests}; do
+    sudo -H "${rootenv[@]}" UNPRIVILEGED_USER="${USER}" "${t}"
+  done
+
   sudo -H "${rootenv[@]}" -s make check-integration \
       CHECK_INTEGRATION_FLAGS=-unprivileged_user="${USER}"
 }

--- a/integration/utils/user.go
+++ b/integration/utils/user.go
@@ -150,4 +150,5 @@ func SetCredential(cmd *exec.Cmd, user *UnixUser) {
 		panic("SetCredential invoked on a cmd object that already includes user credentials")
 	}
 	cmd.SysProcAttr.Credential = user.ToCredential()
+	cmd.SysProcAttr.Credential.NoSetGroups = true
 }

--- a/src/concurrent.rs
+++ b/src/concurrent.rs
@@ -348,12 +348,10 @@ struct IdSetter<T: Copy + Eq> {
     setter: fn(T) -> nix::Result<()>,
 }
 
-#[allow(unused)]  // TODO(jmmv): Remove once used.
 impl<T> IdSetter<T> where T: Copy + Eq {
     /// Sets a global ID of type `T` to `desired` using the `setter` function.
     ///
     /// Does nothing if the given ID matches the return value of `getter`.
-    #[allow(unused)]  // TODO(jmmv): Remove once used.
     #[allow(unsafe_code)]
     unsafe fn set(desired: T, getter: fn() -> T, setter: fn(T) -> nix::Result<()>)
         -> nix::Result<IdSetter<T>> {
@@ -382,7 +380,6 @@ lazy_static! {
 }
 
 /// Runs the arbitrary `code` closure under the desired UID/GID pair.
-#[allow(unused)]  // TODO(jmmv): Remove once used.
 pub fn do_as<T, Code: Fn() -> T>(
     desired_uid: unistd::Uid, desired_gid: unistd::Gid, code: Code) -> Result<T, nix::Error> {
     #[allow(unsafe_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,12 +32,14 @@
 #[macro_use] extern crate failure;
 extern crate fuse;
 extern crate hashbrown;
+#[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
 extern crate nix;
 extern crate serde_derive;
 extern crate signal_hook;
 #[cfg(test)] extern crate tempfile;
 extern crate time;
+#[cfg(test)] extern crate users;
 
 use failure::{Fallible, Error, ResultExt};
 use hashbrown::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -707,7 +707,7 @@ impl reconfig::ReconfigurableFS for ReconfigurableSandboxFS {
 /// Mounts a new sandboxfs instance on the given `mount_point` and maps all `mappings` within it.
 pub fn mount(mount_point: &Path, options: &[&str], mappings: &[Mapping], ttl: Timespec,
     input: fs::File, output: fs::File) -> Fallible<()> {
-    let mut os_options = options.iter().map(|o| o.as_ref()).collect::<Vec<&OsStr>>();
+    let mut os_options = options.iter().map(std::convert::AsRef::as_ref).collect::<Vec<&OsStr>>();
 
     // Delegate permissions checks to the kernel for efficiency and to avoid having to implement
     // them on our own.

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -239,7 +239,7 @@ impl Dir {
         };
 
         let state = MutableDir {
-            parent: parent.map_or(inode, |node| node.inode()),
+            parent: parent.map_or(inode, Node::inode),
             underlying_path: None,
             attr: attr,
             children: HashMap::new(),

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -340,9 +340,9 @@ pub trait Node {
     ///
     /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
     /// nodes, used when create has to instantiate a new node.
-    #[allow(clippy::type_complexity)]
-    fn create(&self, _name: &OsStr, _mode: u32, _flags: u32, _ids: &IdGenerator, _cache: &Cache)
-        -> NodeResult<(ArcNode, ArcHandle, fuse::FileAttr)> {
+    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    fn create(&self, _name: &OsStr, _uid: unistd::Uid, _gid: unistd::Gid, _mode: u32, _flags: u32,
+        _ids: &IdGenerator, _cache: &Cache) -> NodeResult<(ArcNode, ArcHandle, fuse::FileAttr)> {
         panic!("Not implemented")
     }
 
@@ -369,8 +369,9 @@ pub trait Node {
     ///
     /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
     /// nodes, used when create has to instantiate a new node.
-    fn mkdir(&self, _name: &OsStr, _mode: u32, _ids: &IdGenerator, _cache: &Cache)
-        -> NodeResult<(ArcNode, fuse::FileAttr)> {
+    #[allow(clippy::too_many_arguments)]
+    fn mkdir(&self, _name: &OsStr, _uid: unistd::Uid, _gid: unistd::Gid, _mode: u32,
+        _ids: &IdGenerator, _cache: &Cache) -> NodeResult<(ArcNode, fuse::FileAttr)> {
         panic!("Not implemented")
     }
 
@@ -381,8 +382,9 @@ pub trait Node {
     ///
     /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
     /// nodes, used when create has to instantiate a new node.
-    fn mknod(&self, _name: &OsStr, _mode: u32, _rdev: u32, _ids: &IdGenerator, _cache: &Cache)
-        -> NodeResult<(ArcNode, fuse::FileAttr)> {
+    #[allow(clippy::too_many_arguments)]
+    fn mknod(&self, _name: &OsStr, _uid: unistd::Uid, _gid: unistd::Gid, _mode: u32, _rdev: u32,
+        _ids: &IdGenerator, _cache: &Cache) -> NodeResult<(ArcNode, fuse::FileAttr)> {
         panic!("Not implemented")
     }
 
@@ -461,8 +463,8 @@ pub trait Node {
     ///
     /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
     /// nodes, used when create has to instantiate a new node.
-    fn symlink(&self, _name: &OsStr, _link: &Path, _ids: &IdGenerator, _cache: &Cache)
-        -> NodeResult<(ArcNode, fuse::FileAttr)> {
+    fn symlink(&self, _name: &OsStr, _link: &Path, _uid: unistd::Uid, _gid: unistd::Gid,
+        _ids: &IdGenerator, _cache: &Cache) -> NodeResult<(ArcNode, fuse::FileAttr)> {
         panic!("Not implemented")
     }
 


### PR DESCRIPTION
When `--allow=other` is enabled, this ensures that files created in underlying paths have the right ownerships. The need for this has come up in the context of remote execution, where the environment there is... special for historical reasons.

I'm not sure if what I did here is the best way to achieve this, but it seems convoluted. I could think of two approaches: first, the one I went with (changing euid/egid at creation time), and, second, using `chown` right after creating the files. I went with the former approach under the assumption that the global lock is less costly than the doubled number of system calls... but I could be wrong.