### PR TITLE
Allow creating files as different users

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ pkg-config = "0.3"
 
 [dev-dependencies]
 tempfile = "3"
+users = "0.9"

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@
 * Fixed `--input` and `--output` to handle stdin and stdout correctly when
   running e.g. under `sudo`.
 
+* Make create operations honor the UID and GID of the caller user instead of
+  inheriting the permissions of whoever was running sandboxfs.  Only has an
+  effect when using `--allow=other` or `--allow=root`.
+
 ## Changes in version 0.1.0
 
 **Released on 2019-02-05.**

--- a/integration/read_write_test.go
+++ b/integration/read_write_test.go
@@ -49,6 +49,63 @@ func openAndDelete(path string, mode int) (int, error) {
 	return fd, nil
 }
 
+// createAsDifferentUser implements a generic test that creates entries within the mount point
+// as a different user than the one running sandboxfs and checks that the created entries in the
+// underlying tree has the right owner:group settings.
+//
+// The createAsUser lambda is a function responsible for creating the desired type of entry at the
+// given path with the given credentials.
+func createAsDifferentUserTest(t *testing.T, createAsUser func(string, *utils.UnixUser) error) {
+	root := utils.RequireRoot(t, "Requires root privileges")
+
+	user := utils.GetConfig().UnprivilegedUser
+	if user == nil {
+		t.Skipf("unprivileged user not set; must contain the name of an unprivileged user with FUSE access")
+	}
+	t.Logf("Using primary unprivileged user: %v", user)
+
+	state := utils.MountSetupWithUser(t, root, "--mapping=rw:/:%ROOT%", "--allow=other")
+	defer state.TearDown(t)
+
+	utils.MustMkdirAll(t, state.RootPath("dir"), 0777)
+	if err := os.Chown(state.RootPath("dir"), user.UID, user.GID); err != nil {
+		t.Fatalf("Cannot create unprivileged work directory: %v", err)
+	}
+
+	wantFiles := []struct {
+		path string
+		user *utils.UnixUser
+	}{
+		{path: "dir/unprivileged", user: user},
+		{path: "privileged", user: root},
+	}
+	for _, wantFile := range wantFiles {
+		if err := createAsUser(state.MountPath(wantFile.path), wantFile.user); err != nil {
+			t.Fatalf("Cannot create %s as %v: %v", wantFile.path, wantFile.user, err)
+		}
+	}
+
+	// Now that all files were created, make sure they have the right ownerships.
+	for _, wantFile := range wantFiles {
+		// Check that the underlying file has the right ownership, and also check that the
+		// node we recorded in sandboxfs' memory agrees.
+		for _, path := range []string{state.MountPath(wantFile.path), state.RootPath(wantFile.path)} {
+			fileInfo, err := os.Lstat(path)
+			if err != nil {
+				t.Fatalf("Cannot stat %s: %v", path, err)
+			}
+			stat := fileInfo.Sys().(*syscall.Stat_t)
+			if int(stat.Uid) != wantFile.user.UID || int(stat.Gid) != wantFile.user.GID {
+				t.Errorf("%s has wrong ownership; got %v:%v, want %v:%v", path, stat.Uid, stat.Gid, wantFile.user.UID, wantFile.user.GID)
+			}
+		}
+	}
+}
+
+func TestReadWrite_MkdirAsDifferentUser(t *testing.T) {
+	createAsDifferentUserTest(t, utils.MkdirAsUser)
+}
+
 func TestReadWrite_CreateFile(t *testing.T) {
 	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
 	defer state.TearDown(t)
@@ -63,6 +120,10 @@ func TestReadWrite_CreateFile(t *testing.T) {
 	if err := utils.FileEquals(state.MountPath("subdir/file"), "new content"); err != nil {
 		t.Error(err)
 	}
+}
+
+func TestReadWrite_CreateFileAsDifferentUser(t *testing.T) {
+	createAsDifferentUserTest(t, utils.CreateFileAsUser)
 }
 
 func TestReadWrite_Remove(t *testing.T) {
@@ -326,8 +387,6 @@ func equivalentStats(stat1 os.FileInfo, stat2 os.FileInfo) error {
 // Tests calling this function should only start a sandboxfs instance with the desired configuration
 // and then immediately call this function.
 func doRenameTest(t *testing.T, oldOuterPath, newOuterPath, oldInnerPath, newInnerPath string) {
-	t.Helper()
-
 	utils.MustMkdirAll(t, filepath.Dir(oldOuterPath), 0755)
 	utils.MustMkdirAll(t, filepath.Dir(newOuterPath), 0755)
 	utils.MustMkdirAll(t, filepath.Dir(oldInnerPath), 0755)
@@ -493,6 +552,15 @@ func TestReadWrite_MoveRace(t *testing.T) {
 	}
 }
 
+func TestReadWrite_MoveAsDifferentUser(t *testing.T) {
+	createAsDifferentUserTest(t, func(path string, user *utils.UnixUser) error {
+		if err := utils.CreateFileAsUser(path+".old", user); err != nil {
+			return err
+		}
+		return utils.MoveAsUser(path+".old", path, user)
+	})
+}
+
 func TestReadWrite_Mknod(t *testing.T) {
 	utils.RequireRoot(t, "Requires root privileges to create arbitrary nodes")
 
@@ -595,6 +663,9 @@ func TestReadWrite_Mknod(t *testing.T) {
 			}
 		})
 	}
+}
+func TestReadWrite_MknodAsDifferentUser(t *testing.T) {
+	createAsDifferentUserTest(t, utils.MkfifoAsUser)
 }
 
 func TestReadWrite_Chmod(t *testing.T) {
@@ -1013,6 +1084,11 @@ func TestReadWrite_SymlinkAndReadlink(t *testing.T) {
 	if target != gotTarget {
 		t.Errorf("Want symlink target to be %s, got %s", target, gotTarget)
 	}
+}
+func TestReadWrite_SymlinkAsDifferentUser(t *testing.T) {
+	createAsDifferentUserTest(t, func(path string, user *utils.UnixUser) error {
+		return utils.SymlinkAsUser("/non-existent/target", path, user)
+	})
 }
 
 func TestReadWrite_MmapAfterMovesWorks(t *testing.T) {

--- a/integration/utils/user.go
+++ b/integration/utils/user.go
@@ -150,4 +150,5 @@ func SetCredential(cmd *exec.Cmd, user *UnixUser) {
 		panic("SetCredential invoked on a cmd object that already includes user credentials")
 	}
 	cmd.SysProcAttr.Credential = user.ToCredential()
+	cmd.SysProcAttr.Credential.NoSetGroups = true
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -707,7 +707,7 @@ impl reconfig::ReconfigurableFS for ReconfigurableSandboxFS {
 /// Mounts a new sandboxfs instance on the given `mount_point` and maps all `mappings` within it.
 pub fn mount(mount_point: &Path, options: &[&str], mappings: &[Mapping], ttl: Timespec,
     input: fs::File, output: fs::File) -> Fallible<()> {
-    let mut os_options = options.iter().map(|o| o.as_ref()).collect::<Vec<&OsStr>>();
+    let mut os_options = options.iter().map(std::convert::AsRef::as_ref).collect::<Vec<&OsStr>>();
 
     // Delegate permissions checks to the kernel for efficiency and to avoid having to implement
     // them on our own.

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -239,7 +239,7 @@ impl Dir {
         };
 
         let state = MutableDir {
-            parent: parent.map_or(inode, |node| node.inode()),
+            parent: parent.map_or(inode, Node::inode),
             underlying_path: None,
             attr: attr,
             children: HashMap::new(),

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -340,9 +340,9 @@ pub trait Node {
     ///
     /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
     /// nodes, used when create has to instantiate a new node.
-    #[allow(clippy::type_complexity)]
-    fn create(&self, _name: &OsStr, _mode: u32, _flags: u32, _ids: &IdGenerator, _cache: &Cache)
-        -> NodeResult<(ArcNode, ArcHandle, fuse::FileAttr)> {
+    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    fn create(&self, _name: &OsStr, _uid: unistd::Uid, _gid: unistd::Gid, _mode: u32, _flags: u32,
+        _ids: &IdGenerator, _cache: &Cache) -> NodeResult<(ArcNode, ArcHandle, fuse::FileAttr)> {
         panic!("Not implemented")
     }
 
@@ -369,8 +369,9 @@ pub trait Node {
     ///
     /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
     /// nodes, used when create has to instantiate a new node.
-    fn mkdir(&self, _name: &OsStr, _mode: u32, _ids: &IdGenerator, _cache: &Cache)
-        -> NodeResult<(ArcNode, fuse::FileAttr)> {
+    #[allow(clippy::too_many_arguments)]
+    fn mkdir(&self, _name: &OsStr, _uid: unistd::Uid, _gid: unistd::Gid, _mode: u32,
+        _ids: &IdGenerator, _cache: &Cache) -> NodeResult<(ArcNode, fuse::FileAttr)> {
         panic!("Not implemented")
     }
 
@@ -381,8 +382,9 @@ pub trait Node {
     ///
     /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
     /// nodes, used when create has to instantiate a new node.
-    fn mknod(&self, _name: &OsStr, _mode: u32, _rdev: u32, _ids: &IdGenerator, _cache: &Cache)
-        -> NodeResult<(ArcNode, fuse::FileAttr)> {
+    #[allow(clippy::too_many_arguments)]
+    fn mknod(&self, _name: &OsStr, _uid: unistd::Uid, _gid: unistd::Gid, _mode: u32, _rdev: u32,
+        _ids: &IdGenerator, _cache: &Cache) -> NodeResult<(ArcNode, fuse::FileAttr)> {
         panic!("Not implemented")
     }
 
@@ -461,8 +463,8 @@ pub trait Node {
     ///
     /// `_ids` and `_cache` are the file system-wide bookkeeping objects needed to instantiate new
     /// nodes, used when create has to instantiate a new node.
-    fn symlink(&self, _name: &OsStr, _link: &Path, _ids: &IdGenerator, _cache: &Cache)
-        -> NodeResult<(ArcNode, fuse::FileAttr)> {
+    fn symlink(&self, _name: &OsStr, _link: &Path, _uid: unistd::Uid, _gid: unistd::Gid,
+        _ids: &IdGenerator, _cache: &Cache) -> NodeResult<(ArcNode, fuse::FileAttr)> {
         panic!("Not implemented")
     }
 

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -16,10 +16,12 @@
 
 use fuse;
 use nix::{sys, unistd};
+use std::env;
 use std::fs;
 use std::os::unix;
 use std::path::PathBuf;
 use tempfile::{TempDir, tempdir};
+use users;
 
 /// Holds a temporary directory and files of all possible kinds within it.
 ///
@@ -79,5 +81,20 @@ impl AllFileTypes {
         entries.push((fuse::FileType::Symlink, symlink));
 
         AllFileTypes { root, entries }
+    }
+}
+
+/// Holds user-provided configuration details for the tests.
+pub struct Config {
+    /// The unprivileged user for tests that need to drop privileges.  None if unset.
+    pub unprivileged_user: Option<users::User>,
+}
+
+impl Config {
+    /// Queries the test configuration.
+    pub fn get() -> Config {
+        let unprivileged_user = env::var("UNPRIVILEGED_USER")
+            .map(|name| users::get_user_by_name(&name)).unwrap_or(None);
+        Config { unprivileged_user }
     }
 }


### PR DESCRIPTION
When --allow=other is enabled, this ensures that files created in underlying paths have the right ownerships. The need for this has come up in the context of remote execution, where the environment there is... special for historical reasons.

Obsoletes #80.