### PR TITLE
Qualify bare trait objects with 'dyn'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,7 @@ struct ReconfigurableSandboxFS {
 ///
 /// This code is shared by the application of `--mapping` flags and by the application of new
 /// mappings as part of a reconfiguration operation.  We want both processes to behave identically.
-fn apply_mapping(mapping: &Mapping, root: &nodes::Node, ids: &IdGenerator, cache: &Cache)
+fn apply_mapping(mapping: &Mapping, root: &dyn nodes::Node, ids: &IdGenerator, cache: &Cache)
     -> Fallible<()> {
     let all = mapping.path.components().collect::<Vec<_>>();
     debug_assert_eq!(Component::RootDir, all[0], "Paths in mappings are always absolute");

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -220,7 +220,7 @@ impl Dir {
     /// Creates a new scaffold directory to represent an in-memory directory.
     ///
     /// The directory's timestamps are set to `now` and the ownership is set to the current user.
-    pub fn new_empty(inode: u64, parent: Option<&Node>, now: time::Timespec) -> ArcNode {
+    pub fn new_empty(inode: u64, parent: Option<&dyn Node>, now: time::Timespec) -> ArcNode {
         let attr = fuse::FileAttr {
             ino: inode,
             kind: fuse::FileType::Directory,

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -265,7 +265,7 @@ pub trait Handle {
 }
 
 /// A reference-counted `Handle` that's safe to send across threads.
-pub type ArcHandle = Arc<Handle + Send + Sync>;
+pub type ArcHandle = Arc<dyn Handle + Send + Sync>;
 
 /// Abstract representation of a file system node.
 ///
@@ -478,4 +478,4 @@ pub trait Node {
 }
 
 /// A reference-counted `Node` that's safe to send across threads.
-pub type ArcNode = Arc<Node + Send + Sync>;
+pub type ArcNode = Arc<dyn Node + Send + Sync>;


### PR DESCRIPTION
This is to silence the newly-added bare_trait_objects warning and to fix
the Travis CI builds.