### PR TITLE
Add support for extended attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 signal-hook = "0.1"
 time = "0.1"
+xattr = "0.2.2"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@
   inheriting the permissions of whoever was running sandboxfs.  Only has an
   effect when using `--allow=other` or `--allow=root`.
 
+* Added support for extended attributes.
+
 ## Changes in version 0.1.0
 
 **Released on 2019-02-05.**

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -350,8 +350,18 @@ pub trait Node {
     /// Retrieves the node's metadata.
     fn getattr(&self) -> NodeResult<fuse::FileAttr>;
 
+    /// Gets the value of the `_name` exgtended attribute.
+    fn getxattr(&self, _name: &OsStr) -> NodeResult<Option<Vec<u8>>> {
+        panic!("Not implemented");
+    }
+
     /// Creates a handle for an already-open backing file corresponding to this node.
     fn handle_from(&self, _file: fs::File) -> ArcHandle {
+        panic!("Not implemented");
+    }
+
+    /// Gets the list of extended attribute names from the file.
+    fn listxattr(&self) -> NodeResult<xattr::XAttrs> {
         panic!("Not implemented");
     }
 
@@ -401,6 +411,11 @@ pub trait Node {
 
     /// Reads the target of a symlink.
     fn readlink(&self) -> NodeResult<PathBuf> {
+        panic!("Not implemented");
+    }
+
+    /// Removes the `_name` extended attribute.
+    fn removexattr(&self, _name: &OsStr) -> NodeResult<()> {
         panic!("Not implemented");
     }
 
@@ -461,6 +476,11 @@ pub trait Node {
 
     /// Sets one or more properties of the node's metadata.
     fn setattr(&self, _delta: &AttrDelta) -> NodeResult<fuse::FileAttr>;
+
+    /// Sets the `_name` extended attribute to `_value`.
+    fn setxattr(&self, _name: &OsStr, _value: &[u8]) -> NodeResult<()> {
+        panic!("Not implemented");
+    }
 
     /// Creates a symlink with `_name` pointing at `_link`.
     ///


### PR DESCRIPTION
These turn out to be necessary when running tar inside sandboxfs on
macOS.  tar uses the copyfile() call and asks it to copy extended
attributes, and returns an error if it cannot do that.  Only seems
to happen when running as root, however, which is a bit strange.

I'm not making support for xattrs conditional yet, but I suspect
a blanket implementation like this may be detrimental to performance
for the Bazel use case.  If that turns out to be true when measured,
we can add a flag.