### PR TITLE
Update a node's size during writes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@
 * Fixed `--input` and `--output` to handle stdin and stdout correctly when
   running e.g. under `sudo`.
 
+* Fixed a bug where writes on a file descriptor that had been duplicated and
+  closed did not update the file size, resulting in bad data being returned
+  on future reads.
+
 * Make create operations honor the UID and GID of the caller user instead of
   inheriting the permissions of whoever was running sandboxfs.  Only has an
   effect when using `--allow=other` or `--allow=root`.

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -538,7 +538,7 @@ impl Node for Dir {
         let file = create_as(&path, uid, gid, |p| options.open(&p), |p| fs::remove_file(&p))?;
         let (node, attr) = Dir::post_create_lookup(self.writable, &mut state, &path, name,
             fuse::FileType::RegularFile, ids, cache)?;
-        Ok((node, Arc::from(file), attr))
+        Ok((node.clone(), node.handle_from(file), attr))
     }
 
     fn getattr(&self) -> NodeResult<fuse::FileAttr> {

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -19,6 +19,7 @@ use nix;
 use nix::errno::Errno;
 use nix::{sys, unistd};
 use std::ffi::OsStr;
+use std::fs;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 use std::result::Result;
@@ -348,6 +349,11 @@ pub trait Node {
 
     /// Retrieves the node's metadata.
     fn getattr(&self) -> NodeResult<fuse::FileAttr>;
+
+    /// Creates a handle for an already-open backing file corresponding to this node.
+    fn handle_from(&self, _file: fs::File) -> ArcHandle {
+        panic!("Not implemented");
+    }
 
     /// Looks up a node with the given name within the current node and returns the found node and
     /// its attributes at the time of the query.


### PR DESCRIPTION
When writing to a file descriptor that had been dupped and then closed,
the writes would be "lost" because we did not update the file's size.
This only happened under this condition because, when a file is deleted,
we start serving getattr requests purely from memory (which then get a
stale size value); and because when a file is dupped, the kernel behaves
differently.  (I suspect the duplicated handle gets a copy of the bad
size or something like that but I haven't investigated; sandboxfs's
behavior was obviously buggy.)

This fixes bmake -jN builds when pointing TMPDIR into sandboxfs.  These
builds would seem to make progress but none of the subprocesses executed
at all.  The strange thing is that bmake reported no errors, and it seems
the syscalls themselves didn't either.