### PR TITLE
Prevent recreating dir nodes in readdir

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 **Released 2019-10-24.**
 
+* Issue #92: Fixed a bug in `readdir` where we would regenerate inodes for
+  directory entries, causing later confusion when trying to access those directories.
+
 * Fixed the definition of `--input` and `--output` to require an argument,
   which makes `--foo bar` and `--foo=bar` equivalent.  This can be thought to
   break backwards compatibility but, in reality, it does not.  The previous


### PR DESCRIPTION
The readdir implementation would generate new nodes for every directory
it encountered, even if they had seen before, returning new inodes each
time.  Other than this having a performance impact, this is just
incorrect and I'm not sure how this bug has survived for so long.

In fact, the only reason I noticed this is because I tried to build
GNU tar on top of sandboxfs and its configure script would fail when
run as root.  Essentially, the test was doing a rename of a directory
inside a directory, and that somehow caused the pwd to become invalid
when performing a readdir on the parent directory.  The issue is easier
to reproduce on Linux though.

Fixes #92.