### PR TITLE
Make hardlink counts drop on deletion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,9 @@
 * Fixed timestamp updates so that the `birthtime` rolls back to an older
   `mtime` to mimic BSD semantics.
 
+* Fixed hardlink counts so that they are zero for handles that point to
+  deleted files or directories.
+
 * Make create operations honor the UID and GID of the caller user instead of
   inheriting the permissions of whoever was running sandboxfs.  Only has an
   effect when using `--allow=other` or `--allow=root`.


### PR DESCRIPTION
Minor fix to ensure deleted files have a hard link count of zero if they
happen to still be open.

The same applies to subdirectories, which get their count decremented and
thus becomes 1, but this is not as important: file systems seem to behave
in very different ways regarding this (e.g. APFS keeps the number at 2).