### PR TITLE
Update paths of directory contents after a rename

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@
 * Issue #92: Fixed a bug in `readdir` where we would regenerate inodes for
   directory entries, causing later confusion when trying to access those directories.
 
+* Issue #94: Fixed a bug in `rename` that caused moved directories to lose
+  access to their contents (because the underlying paths for their
+  descendents wouldn't be updated to point to their new locations).
+
 * Fixed the definition of `--input` and `--output` to require an argument,
   which makes `--foo bar` and `--foo=bar` equivalent.  This can be thought to
   break backwards compatibility but, in reality, it does not.  The previous

--- a/integration/read_write_test.go
+++ b/integration/read_write_test.go
@@ -735,6 +735,29 @@ func TestReadWrite_MoveAsDifferentUser(t *testing.T) {
 	})
 }
 
+func TestReadWrite_MoveDirectoryUpdatesContents(t *testing.T) {
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
+	defer state.TearDown(t)
+
+	// Create the files directly in the mount path, as opposed to the root path (like other
+	// tests do), to ensure sandboxfs creates in-memory nodes for them.
+	utils.MustMkdirAll(t, state.MountPath("dir1"), 0755)
+	utils.MustWriteFile(t, state.MountPath("dir1/file"), 0644, "First file")
+	utils.MustMkdirAll(t, state.MountPath("dir1/subdir"), 0755)
+	utils.MustWriteFile(t, state.MountPath("dir1/subdir/file"), 0644, "Second file")
+
+	if err := os.Rename(state.MountPath("dir1"), state.MountPath("dir2")); err != nil {
+		t.Fatalf("Rename failed: %v", err)
+	}
+
+	if err := utils.FileEquals(state.MountPath("dir2/file"), "First file"); err != nil {
+		t.Fatalf("dir2/file is invalid: %v", err)
+	}
+	if err := utils.FileEquals(state.MountPath("dir2/subdir/file"), "Second file"); err != nil {
+		t.Fatalf("dir2/subdir/file is invalid: %v", err)
+	}
+}
+
 func TestReadWrite_Mknod(t *testing.T) {
 	utils.RequireRoot(t, "Requires root privileges to create arbitrary nodes")
 


### PR DESCRIPTION
When renaming a directory, make sure to update the underlying paths for
all of the nodes it contains to point at the new locations.  Otherwise,
subsequent attempts to access those nodes result in ENOENT.

Fixes #94.