### PR TITLE
Fold cache updates into delete/set_underlying_path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,8 +7,8 @@
 * Issue #92: Fixed a bug in `readdir` where we would regenerate inodes for
   directory entries, causing later confusion when trying to access those directories.
 
-* Issue #94: Fixed a bug in `rename` that caused moved directories to lose
-  access to their contents (because the underlying paths for their
+* Issues #94, #98: Fixed a bug in `rename` that caused moved directories to
+  lose access to their contents (because the underlying paths for their
   descendents wouldn't be updated to point to their new locations).
 
 * Fixed the definition of `--input` and `--output` to require an argument,

--- a/integration/read_write_test.go
+++ b/integration/read_write_test.go
@@ -758,6 +758,26 @@ func TestReadWrite_MoveDirectoryUpdatesContents(t *testing.T) {
 	}
 }
 
+func TestReadWrite_DeleteAfterMovedDirectory(t *testing.T) {
+	state := utils.MountSetup(t, "--mapping=rw:/:%ROOT%")
+	defer state.TearDown(t)
+
+	// Create the files directly in the mount path, as opposed to the root path (like other
+	// tests do), to ensure sandboxfs creates in-memory nodes for them.
+	utils.MustMkdirAll(t, state.MountPath("dir1"), 0755)
+	utils.MustWriteFile(t, state.MountPath("dir1/file"), 0644, "First file")
+	utils.MustMkdirAll(t, state.MountPath("dir1/subdir"), 0755)
+	utils.MustWriteFile(t, state.MountPath("dir1/subdir/file"), 0644, "Second file")
+
+	if err := os.Rename(state.MountPath("dir1"), state.MountPath("dir2")); err != nil {
+		t.Fatalf("Rename failed: %v", err)
+	}
+
+	if err := os.RemoveAll(state.MountPath("dir2")); err != nil {
+		t.Errorf("Remove failed: %v", err)
+	}
+}
+
 func TestReadWrite_Mknod(t *testing.T) {
 	utils.RequireRoot(t, "Requires root privileges to create arbitrary nodes")
 

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -321,10 +321,14 @@ pub trait Node {
     ///
     /// The implication of this is that a node loses its backing underlying path once this method
     /// is called.
-    fn delete(&self);
+    ///
+    /// `_cache` is updated to remove the path if the underlying file is deleted.
+    fn delete(&self, _cache: &Cache);
 
     /// Updates the node's underlying path to the given one.  Needed for renames.
-    fn set_underlying_path(&self, _path: &Path);
+    ///
+    /// `_cache` is updated to reflect the rename of the underlying path.
+    fn set_underlying_path(&self, _path: &Path, _cache: &Cache);
 
     /// Maps a path onto a node and creates intermediate components as immutable directories.
     ///

--- a/src/nodes/symlink.rs
+++ b/src/nodes/symlink.rs
@@ -14,6 +14,7 @@
 
 extern crate fuse;
 
+use Cache;
 use nix::errno;
 use nodes::{ArcNode, AttrDelta, KernelError, Node, NodeResult, conv, setattr};
 use std::ffi::OsStr;
@@ -88,18 +89,21 @@ impl Node for Symlink {
         fuse::FileType::Symlink
     }
 
-    fn delete(&self) {
+    fn delete(&self, cache: &Cache) {
         let mut state = self.state.lock().unwrap();
         assert!(
             state.underlying_path.is_some(),
             "Delete already called or trying to delete an explicit mapping");
+        cache.delete(state.underlying_path.as_ref().unwrap(), state.attr.kind);
         state.underlying_path = None;
     }
 
-    fn set_underlying_path(&self, path: &Path) {
+    fn set_underlying_path(&self, path: &Path, cache: &Cache) {
         let mut state = self.state.lock().unwrap();
         debug_assert!(state.underlying_path.is_some(),
             "Renames should not have been allowed in scaffold or deleted nodes");
+        cache.rename(
+            state.underlying_path.as_ref().unwrap(), path.to_owned(), state.attr.kind);
         state.underlying_path = Some(PathBuf::from(path));
         debug_assert!(state.attr.nlink >= 1);
         state.attr.nlink -= 1;


### PR DESCRIPTION
This ensures that the cache is always updated when we modify the
underying paths, which is important now that, on directory renames,
we do a recursive traversal to update all descendents.

Fixes #98.