### PR TITLE
Disable the node cache and add a flag to enable it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ env:
   - DO=package
   - DO=test
   - DO=test FEATURES=profiling
+  - DO=test FLAGS=--node_cache
 
 jobs:
   include:

--- a/Makefile.in
+++ b/Makefile.in
@@ -44,6 +44,8 @@ check: check-unit check-integration
 check-unit: Cargo.toml $(RUST_SRCS)
 	RUST_BACKTRACE=full $(CARGO) test $(CARGO_FLAGS) --verbose
 
+SANDBOXFS_BINARY = $$(pwd)/target/debug/sandboxfs
+
 @IS_BMAKE@GO_SRCS != find integration -name "*.go"
 @IS_GNUMAKE@GO_SRCS = $(shell find integration -name "*.go")
 check-integration: target/debug/sandboxfs $(GO_SRCS)
@@ -53,7 +55,7 @@ check-integration: target/debug/sandboxfs $(GO_SRCS)
 	        -v -timeout=600s \
 	        github.com/bazelbuild/sandboxfs/integration \
 	        -features="$(FEATURES)" \
-	        -sandboxfs_binary="$$(pwd)/target/debug/sandboxfs" \
+	        -sandboxfs_binary="$(SANDBOXFS_BINARY)" \
 	        $(CHECK_INTEGRATION_FLAGS); \
 	else \
 	    echo "WARNING: Go not enabled; integration tests not run"; \

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,12 @@
 * Added support to change the timestamps of a symlink on systems that have
   this feature.
 
+* Disabled the path-based node cache by default and added a `--node_cache`
+  flag to reenable it. This fixes crashes running Java within a sandboxfs
+  instance where the Java toolchain is mapped under multiple locations and
+  the first mapped location vanishes. See [The OSXFUSE, hard links, and dladdr
+  puzzle](https://jmmv.dev/2020/01/osxfuse-hardlinks-dladdr.html) for details.
+
 ## Changes in version 0.1.0
 
 **Released on 2019-02-05.**

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -38,6 +38,7 @@ Options:
     --input PATH        where to read reconfiguration data from (- for stdin)
     --mapping TYPE:PATH:UNDERLYING_PATH
                         type and locations of a mapping
+    --node_cache        enables the path-based node cache (known broken)
     --output PATH       where to write the reconfiguration status to (- for
                         stdout)
     --ttl TIMEs         how long the kernel is allowed to keep file metadata

--- a/integration/nesting_test.go
+++ b/integration/nesting_test.go
@@ -87,7 +87,7 @@ func TestNesting_ReadWriteWithinReadOnly(t *testing.T) {
 }
 
 func TestNesting_SameTarget(t *testing.T) {
-	state := utils.MountSetup(t, "--mapping=ro:/:%ROOT%", "--mapping=rw:/dir1:%ROOT%/same", "--mapping=rw:/dir2/dir3/dir4:%ROOT%/same")
+	state := utils.MountSetup(t, "--node_cache", "--mapping=ro:/:%ROOT%", "--mapping=rw:/dir1:%ROOT%/same", "--mapping=rw:/dir2/dir3/dir4:%ROOT%/same")
 	defer state.TearDown(t)
 
 	utils.MustWriteFile(t, state.MountPath("dir1/file"), 0644, "old contents")

--- a/man/sandboxfs.1
+++ b/man/sandboxfs.1
@@ -11,7 +11,7 @@
 .\" WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 .\" License for the specific language governing permissions and limitations
 .\" under the License.
-.Dd February 25, 2020
+.Dd February 26, 2020
 .Dt SANDBOXFS 1
 .Os
 .Sh NAME
@@ -24,6 +24,7 @@
 .Op Fl -input Ar path
 .Op Fl -help
 .Op Fl -mapping Ar type:mapping:target
+.Op Fl -node_cache
 .Op Fl -output Ar path
 .Op Fl -ttl Ar duration
 .Op Fl -version
@@ -117,6 +118,22 @@ is not repeated.
 See the
 .Sx Mapping specifications
 subsection for details on how a mapping is specified.
+.It Fl -node_cache
+Enables the path-based node cache, which causes nodes to be reused across
+reconfigurations when they map to the same underlying paths.
+This should offer a performance boost when the same set of files are mapped
+over and over again across different reconfiguration operations.
+.Pp
+This cache used to be enabled by default but it turned out to be problematic.
+For example, on macOS, OSXFUSE seems to keep track of the path where a node
+first appeared, which causes trouble if the node disappears and then reappears
+in a different location (for example,
+.Xr dladdr 3
+returns invalid paths).
+For this reason, the cache is now disabled by default but is still kept around
+in the code for experimentation.
+.Em The cache may be removed in a future release altogether if these problems
+.Em cannot be worked around.
 .It Fl -output Ar path
 Points to the file to which to write confirmations of reconfiguration, or
 .Sq -
@@ -359,13 +376,16 @@ The following are known limitations of
 .It
 Hard links are not supported.
 .It
-On macOS, mapping the same external file or directory under two different
-locations within the mount point results in undefined behavior.
+Mapping the same external file or directory under two different locations within
+the mount point results in undefined behavior.
 Writes may not be reflected at both mapped locations at the same time, which
 can lead to data corruption.
 This is true even for read-only mappings because each separate view within
 the mount point may have cached different contents, returning different data
 than what's truly on disk.
+Using
+.Fl -node_cache
+may help mitigate this issue but it doesn't always do.
 .It
 The
 .Fl -allow Ar root

--- a/src/nodes/caches.rs
+++ b/src/nodes/caches.rs
@@ -1,0 +1,172 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+use {fuse, IdGenerator};
+use nodes::{ArcNode, Cache, Dir, File, Symlink};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Cache of sandboxfs nodes indexed by their underlying path.
+///
+/// This cache is critical to offer good performance during reconfigurations: if the identity of an
+/// underlying file changes across reconfigurations, the kernel will think it's a different file
+/// (even if it may not be) and will therefore not be able to take advantage of any caches.  You
+/// would think that avoiding kernel cache invalidations during the reconfiguration itself (e.g. if
+/// file `A` was mapped and is still mapped now, don't invalidate it) would be sufficient to avoid
+/// this problem, but it's not: `A` could be mapped, then unmapped, and then remapped again in three
+/// different reconfigurations, and we'd still not want to lose track of it.
+///
+/// Nodes should be inserted in this cache at creation time and removed from it when explicitly
+/// deleted by the user (because there is a chance they'll be recreated, and at that point we truly
+/// want to reload the data from disk).
+///
+/// TODO(jmmv): There currently is no cache expiration, which means that memory usage can grow
+/// unboundedly.  A preliminary attempt at expiring cache entries on a node's forget handler sounded
+/// promising (because then cache expiration would be delegated to the kernel)... but, on Linux, the
+/// kernel seems to be calling this very eagerly, rendering our cache useless.  I did not track down
+/// what exactly triggered the forget notifications though.
+#[derive(Default)]
+pub struct PathCache {
+    entries: Mutex<HashMap<PathBuf, ArcNode>>,
+}
+
+impl Cache for PathCache {
+    fn get_or_create(&self, ids: &IdGenerator, underlying_path: &Path, attr: &fs::Metadata,
+        writable: bool) -> ArcNode {
+        if attr.is_dir() {
+            // Directories cannot be cached because they contain entries that are created only
+            // in memory based on the mappings configuration.
+            //
+            // TODO(jmmv): Actually, they *could* be cached, but it's hard.  Investigate doing so
+            // after quantifying how much it may benefit performance.
+            return Dir::new_mapped(ids.next(), underlying_path, attr, writable);
+        }
+
+        let mut entries = self.entries.lock().unwrap();
+
+        if let Some(node) = entries.get(underlying_path) {
+            if node.writable() == writable {
+                // We have a match from the cache!  Return it immediately.
+                //
+                // It is tempting to ensure that the type of the cached node matches the type we
+                // want to return based on the metadata we have now in `attr`... but doing so does
+                // not really prevent problems: the type of the underlying file can change at any
+                // point in time.  We could check this here and the type could change immediately
+                // afterwards behind our backs, so don't bother.
+                return node.clone();
+            }
+
+            // We had a match... but node writability has changed; recreate the node.
+            //
+            // You may wonder why we care about this and not the file type as described above: the
+            // reason is that the writability property is a setting of the mappings, not a property
+            // of the underlying files, and thus it's a setting that we fully control and must keep
+            // correct across reconfigurations or across different mappings of the same files.
+            info!("Missed node caching opportunity because writability has changed for {:?}",
+                underlying_path)
+        }
+
+        let node: ArcNode = if attr.is_dir() {
+            panic!("Directory entries cannot be cached and are handled above");
+        } else if attr.file_type().is_symlink() {
+            Symlink::new_mapped(ids.next(), underlying_path, attr, writable)
+        } else {
+            File::new_mapped(ids.next(), underlying_path, attr, writable)
+        };
+        entries.insert(underlying_path.to_path_buf(), node.clone());
+        node
+    }
+
+    fn delete(&self, path: &Path, file_type: fuse::FileType) {
+        let mut entries = self.entries.lock().unwrap();
+        if file_type == fuse::FileType::Directory {
+            debug_assert!(!entries.contains_key(path), "Directories are not currently cached");
+        } else {
+            entries.remove(path).expect("Tried to delete unknown path from the cache");
+        }
+    }
+
+    fn rename(&self, old_path: &Path, new_path: PathBuf, file_type: fuse::FileType) {
+        let mut entries = self.entries.lock().unwrap();
+        if file_type == fuse::FileType::Directory {
+            debug_assert!(!entries.contains_key(old_path), "Directories are not currently cached");
+        } else {
+            let node = entries.remove(old_path).expect("Tried to rename unknown path in the cache");
+            entries.insert(new_path, node);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use testutils;
+
+    #[test]
+    fn path_cache_behavior() {
+        let root = tempdir().unwrap();
+
+        let dir1 = root.path().join("dir1");
+        fs::create_dir(&dir1).unwrap();
+        let dir1attr = fs::symlink_metadata(&dir1).unwrap();
+
+        let file1 = root.path().join("file1");
+        drop(fs::File::create(&file1).unwrap());
+        let file1attr = fs::symlink_metadata(&file1).unwrap();
+
+        let file2 = root.path().join("file2");
+        drop(fs::File::create(&file2).unwrap());
+        let file2attr = fs::symlink_metadata(&file2).unwrap();
+
+        let ids = IdGenerator::new(1);
+        let cache = PathCache::default();
+
+        // Directories are not cached no matter what.
+        assert_eq!(1, cache.get_or_create(&ids, &dir1, &dir1attr, false).inode());
+        assert_eq!(2, cache.get_or_create(&ids, &dir1, &dir1attr, false).inode());
+        assert_eq!(3, cache.get_or_create(&ids, &dir1, &dir1attr, true).inode());
+
+        // Different files get different nodes.
+        assert_eq!(4, cache.get_or_create(&ids, &file1, &file1attr, false).inode());
+        assert_eq!(5, cache.get_or_create(&ids, &file2, &file2attr, true).inode());
+
+        // Files we queried before but with different writability get different nodes.
+        assert_eq!(6, cache.get_or_create(&ids, &file1, &file1attr, true).inode());
+        assert_eq!(7, cache.get_or_create(&ids, &file2, &file2attr, false).inode());
+
+        // We get cache hits when everything matches previous queries.
+        assert_eq!(6, cache.get_or_create(&ids, &file1, &file1attr, true).inode());
+        assert_eq!(7, cache.get_or_create(&ids, &file2, &file2attr, false).inode());
+
+        // We don't get cache hits for nodes whose writability changed.
+        assert_eq!(8, cache.get_or_create(&ids, &file1, &file1attr, false).inode());
+        assert_eq!(9, cache.get_or_create(&ids, &file2, &file2attr, true).inode());
+    }
+
+    #[test]
+    fn path_cache_nodes_support_all_file_types() {
+        let ids = IdGenerator::new(1);
+        let cache = PathCache::default();
+
+        for (_fuse_type, path) in testutils::AllFileTypes::new().entries {
+            let fs_attr = fs::symlink_metadata(&path).unwrap();
+            // The following panics if it's impossible to represent the given file type, which is
+            // what we are testing.
+            cache.get_or_create(&ids, &path, &fs_attr, false);
+        }
+    }
+}

--- a/src/nodes/file.rs
+++ b/src/nodes/file.rs
@@ -14,9 +14,9 @@
 
 extern crate fuse;
 
-use Cache;
 use nix::errno;
-use nodes::{ArcHandle, ArcNode, AttrDelta, Handle, KernelError, Node, NodeResult, conv, setattr};
+use nodes::{
+    ArcHandle, ArcNode, AttrDelta, Cache, Handle, KernelError, Node, NodeResult, conv, setattr};
 use std::ffi::OsStr;
 use std::fs;
 use std::os::unix::fs::FileExt;
@@ -148,7 +148,7 @@ impl Node for File {
         state.attr.kind
     }
 
-    fn delete(&self, cache: &Cache) {
+    fn delete(&self, cache: &dyn Cache) {
         let mut state = self.state.lock().unwrap();
         assert!(
             state.underlying_path.is_some(),
@@ -159,7 +159,7 @@ impl Node for File {
         state.attr.nlink -= 1;
     }
 
-    fn set_underlying_path(&self, path: &Path, cache: &Cache) {
+    fn set_underlying_path(&self, path: &Path, cache: &dyn Cache) {
         let mut state = self.state.lock().unwrap();
         debug_assert!(state.underlying_path.is_some(),
             "Renames should not have been allowed in scaffold or deleted nodes");

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -26,7 +26,7 @@ use std::result::Result;
 use std::sync::Arc;
 
 mod caches;
-pub use self::caches::PathCache;
+pub use self::caches::{NoCache, PathCache};
 pub mod conv;
 mod dir;
 pub use self::dir::Dir;

--- a/src/nodes/symlink.rs
+++ b/src/nodes/symlink.rs
@@ -14,9 +14,8 @@
 
 extern crate fuse;
 
-use Cache;
 use nix::errno;
-use nodes::{ArcNode, AttrDelta, KernelError, Node, NodeResult, conv, setattr};
+use nodes::{ArcNode, AttrDelta, Cache, KernelError, Node, NodeResult, conv, setattr};
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -89,7 +88,7 @@ impl Node for Symlink {
         fuse::FileType::Symlink
     }
 
-    fn delete(&self, cache: &Cache) {
+    fn delete(&self, cache: &dyn Cache) {
         let mut state = self.state.lock().unwrap();
         assert!(
             state.underlying_path.is_some(),
@@ -98,7 +97,7 @@ impl Node for Symlink {
         state.underlying_path = None;
     }
 
-    fn set_underlying_path(&self, path: &Path, cache: &Cache) {
+    fn set_underlying_path(&self, path: &Path, cache: &dyn Cache) {
         let mut state = self.state.lock().unwrap();
         debug_assert!(state.underlying_path.is_some(),
             "Renames should not have been allowed in scaffold or deleted nodes");


### PR DESCRIPTION
The node cache has turned out to be problematic, especially on macOS where
we get Java crashes when the toolchain is mapped under multiple sandboxes
and the first sandbox in which it was mapped disappears.
    
I should probably just remove the cache implementation altogether, but I'm
still nervous about losing what-I-think-is a pretty important performance
optimization.  Furthermore, 0.2.0 has already piled up too many changes,
so doing this blindly would be risky.  Therefore, I'm adding a --node_cache
flag to bring the cache back, but this is probably going to go away to
significantly simplify the code.