### PR TITLE
Delay format calls in error contexts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Major changes between releases
 
+## Changes in version X.Y.Z
+
+**STILL UNDER DEVELOPMENT; NOT RELEASED YET.**
+
+*   Issue #111: Optimized map operations, cutting down their CPU time by
+    about 15%.
+
 ## Changes in version 0.2.0
 
 **Released on 2020-04-20.**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,8 +234,8 @@ fn create_root(mappings: &[Mapping], ids: &IdGenerator, cache: &dyn nodes::Cache
         let first = &mappings[0];
         if first.is_root() {
             let fs_attr = fs::symlink_metadata(&first.underlying_path)
-                .context(format!("Failed to map root: stat failed for {:?}",
-                                 &first.underlying_path))?;
+                .with_context(|_| format!("Failed to map root: stat failed for {:?}",
+                    &first.underlying_path))?;
             ensure!(fs_attr.is_dir(), "Failed to map root: {:?} is not a directory",
                     &first.underlying_path);
             (nodes::Dir::new_mapped(ids.next(), &first.underlying_path, &fs_attr, first.writable),
@@ -247,7 +247,7 @@ fn create_root(mappings: &[Mapping], ids: &IdGenerator, cache: &dyn nodes::Cache
 
     for mapping in rest {
         apply_mapping(mapping, root.as_ref(), ids, cache)
-            .context(format!("Cannot map '{}'", mapping))?;
+            .with_context(|_| format!("Cannot map '{}'", mapping))?;
     }
 
     Ok(root)
@@ -793,7 +793,7 @@ impl reconfig::ReconfigurableFS for ReconfigurableSandboxFS {
                     let m = Mapping::from_parts(
                         path, mapping.underlying_path.clone(), mapping.writable)?;
                     apply_mapping(&m, self.root.as_ref(), self.ids.as_ref(), self.cache.as_ref())
-                        .context(format!("Cannot map '{}'", mapping))?
+                        .with_context(|_| format!("Cannot map '{}'", mapping))?
                 } else {
                     self.root.find_subdir(OsStr::new(id), self.ids.as_ref())?
                 }
@@ -808,7 +808,7 @@ impl reconfig::ReconfigurableFS for ReconfigurableSandboxFS {
         for mapping in mappings {
             apply_mapping(
                 mapping, root_node.clone().as_ref(), self.ids.as_ref(), self.cache.as_ref())
-                .context(format!("Cannot map '{}'", mapping))?;
+                    .with_context(|_| format!("Cannot map '{}'", mapping))?;
         }
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,14 +253,14 @@ fn safe_main(program: &str, args: &[String]) -> Fallible<()> {
     let input = {
         let input_flag = matches.opt_str("input");
         sandboxfs::open_input(file_flag(&input_flag))
-            .context(format!("Failed to open reconfiguration input '{}'",
+            .with_context(|_| format!("Failed to open reconfiguration input '{}'",
                 input_flag.unwrap_or_else(|| DEFAULT_INOUT.to_owned())))?
     };
 
     let output = {
         let output_flag = matches.opt_str("output");
         sandboxfs::open_output(file_flag(&output_flag))
-            .context(format!("Failed to open reconfiguration output '{}'",
+            .with_context(|_| format!("Failed to open reconfiguration output '{}'",
                 output_flag.unwrap_or_else(|| DEFAULT_INOUT.to_owned())))?
     };
 
@@ -296,7 +296,7 @@ fn safe_main(program: &str, args: &[String]) -> Fallible<()> {
     sandboxfs::mount(
         mount_point, &options, &mappings, ttl, node_cache, matches.opt_present("xattrs"),
         input, output, reconfig_threads)
-        .context(format!("Failed to mount {}", mount_point.display()))?;
+        .with_context(|_| format!("Failed to mount {}", mount_point.display()))?;
     Ok(())
 }
 

--- a/src/nodes/dir.rs
+++ b/src/nodes/dir.rs
@@ -536,7 +536,7 @@ impl Node for Dir {
 
         let child = if remainder.is_empty() {
             let fs_attr = fs::symlink_metadata(underlying_path)
-                .context(format!("Stat failed for {:?}", underlying_path))?;
+                .with_context(|_| format!("Stat failed for {:?}", underlying_path))?;
             cache.get_or_create(ids, underlying_path, &fs_attr, writable)
         } else {
             self.new_scaffold_child(state.underlying_path.as_ref(), name, ids, time::get_time())


### PR DESCRIPTION
It turns out that string formatting is quite expensive as part of mapping
operations (surprise!) and we were doing some unnecessary calls to construct
error messages that are never used.  So, instead of using cause(), switch
to using with_cause() so that we can delay the calls to format!() to when
they are strictly needed.

Should cut about 15% of the CPU time spent within map operations per the
measurements done by @beasleyr-vmw.

Fixes #111.