### PR TITLE
Get GOROOT config from "go env"

### DIFF
--- a/configure
+++ b/configure
@@ -110,7 +110,7 @@ setup_go() {
     [ "${user_override}" = none ] || GOROOT="${user_override}"
   else
     local go="$(find_progs go)"
-    [ -n "${go}" ] && GOROOT="$(dirname "$(dirname "${go}")")"
+    [ -n "${go}" ] && GOROOT="$("${go}" env GOROOT)"
   fi
 
   if [ -z "${GOROOT}" ]; then


### PR DESCRIPTION
In typical cases, this gives the same result as the existing logic.

On my system, "go env" gives the correct answer and the existing logic
does not.

I use the [nix package manager](https://nixos.org/) to manage my
packages, including go. As a result, the go program in my PATH is a
symlink. If you go up two directories from it, you get the directory
containing all of my installed packages, not the go installation
directory. But if you call `go env GOROOT`, it prints the correct path.